### PR TITLE
Handle malformed membership level options

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.1
+- Hardened the membership product seeder to gracefully handle corrupted membership level option values.
+
 ### 0.3.0
 - Renamed plugin to **TCN Platform** and introduced module toggles.
 - Integrated the GN Password Login REST API directly into the codebase with backwards-compatible class aliasing.

--- a/includes/Membership/MembershipModule.php
+++ b/includes/Membership/MembershipModule.php
@@ -597,9 +597,21 @@ class MembershipModule {
             return;
         }
 
-        $levels = Options::get_levels();
+        $levels          = Options::get_levels();
+        $default_levels  = Options::default_levels();
 
         foreach ( $levels as $key => $level ) {
+            $level_defaults = $default_levels[ $key ] ?? array(
+                'name' => is_string( $key ) ? ucwords( str_replace( '_', ' ', $key ) ) : __( 'Membership', 'tcnapp-connector' ),
+                'fee'  => 0,
+            );
+
+            if ( ! is_array( $level ) ) {
+                $level = $level_defaults;
+            } else {
+                $level = wp_parse_args( $level, $level_defaults );
+            }
+
             $existing = get_posts( array(
                 'post_type'      => 'product',
                 'posts_per_page' => 1,

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.0
+Stable tag: 0.3.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -47,6 +47,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.1 =
+* Harden membership product seeding against malformed level options that could trigger a fatal error during activation.
+
 = 0.3.0 =
 * Renamed the combined package to **TCN Platform**.
 * Integrated the GN Password Login API service, added module toggles, and exposed CORS/HTTPS configuration in the admin.
@@ -61,6 +64,9 @@ Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (
 (See previous entries for earlier releases.)
 
 == Upgrade Notice ==
+= 0.3.1 =
+Prevents activation failures when legacy membership level options contain unexpected data structures.
+
 = 0.3.0 =
 New modular architecture plus integrated password login endpoints. Review module settings after updating.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.0
+ * Version:           0.3.1
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.0' );
+define( 'TCN_PLATFORM_VERSION', '0.3.1' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- harden the membership product seeding routine to fall back to defaults when level options are malformed
- bump the plugin version to 0.3.1 and document the changelog and upgrade notice updates

## Testing
- php -l includes/Membership/MembershipModule.php

------
https://chatgpt.com/codex/tasks/task_e_68e0d7fd338883278e19e8dc65e0b06e