### PR TITLE
Fix sponsor capture fatal error and release 0.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.2
+- Resolve a fatal error triggered on `init` when capturing sponsors by making the hooked callback public.
+
 ### 0.3.1
 - Hardened the membership product seeder to gracefully handle corrupted membership level option values.
 

--- a/includes/Membership/MembershipModule.php
+++ b/includes/Membership/MembershipModule.php
@@ -555,7 +555,7 @@ class MembershipModule {
         );
     }
 
-    protected function maybe_capture_sponsor(): void {
+    public function maybe_capture_sponsor(): void {
         if ( headers_sent() ) {
             return;
         }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.1
+Stable tag: 0.3.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -47,6 +47,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.2 =
+* Fix a fatal error on `init` by making the sponsor capture callback public so it can be used as an action hook.
+
 = 0.3.1 =
 * Harden membership product seeding against malformed level options that could trigger a fatal error during activation.
 
@@ -64,6 +67,9 @@ Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (
 (See previous entries for earlier releases.)
 
 == Upgrade Notice ==
+= 0.3.2 =
+Addresses a fatal error thrown on sites hooking into sponsor capture during `init`.
+
 = 0.3.1 =
 Prevents activation failures when legacy membership level options contain unexpected data structures.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.1
+ * Version:           0.3.2
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.1' );
+define( 'TCN_PLATFORM_VERSION', '0.3.2' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- make the MembershipModule::maybe_capture_sponsor callback public so it can be hooked without triggering a fatal error
- bump the plugin version to 0.3.2 and document the fix in the readme files

## Testing
- php -l includes/Membership/MembershipModule.php

------
https://chatgpt.com/codex/tasks/task_e_68e0da771764832799b3cb69a210f815