### PR TITLE
Handle invalid membership level data on settings page

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.3
+- Prevent a fatal error on the admin settings screen when membership level option data is unexpectedly stored as strings.
+
 ### 0.3.2
 - Resolve a fatal error triggered on `init` when capturing sponsors by making the hooked callback public.
 

--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -69,6 +69,10 @@ class SettingsPage {
         $modules        = $this->modules->all();
         $login_settings = Options::get_login_settings();
         $levels         = Options::get_levels();
+
+        if ( ! is_array( $levels ) ) {
+            $levels = array();
+        }
         $general        = Options::get_general_settings();
         $currency       = isset( $general['currency'] ) ? $general['currency'] : 'USD';
 
@@ -162,11 +166,30 @@ class SettingsPage {
                         </tr>
                     </thead>
                     <tbody>
-                        <?php foreach ( $levels as $level ) : ?>
+                        <?php
+                        foreach ( $levels as $level ) :
+                            if ( ! is_array( $level ) ) {
+                                $level = array( 'name' => (string) $level );
+                            }
+
+                            $level = wp_parse_args(
+                                $level,
+                                array(
+                                    'name'               => '',
+                                    'benefits'           => array(),
+                                    'fee'                => 0,
+                                    'commission_direct'  => 0,
+                                    'commission_passive' => 0,
+                                )
+                            );
+
+                            $benefits = array_filter( (array) $level['benefits'], 'strlen' );
+                            $benefits = array_map( 'wp_strip_all_tags', $benefits );
+                        ?>
                             <tr>
                                 <td>
                                     <strong><?php echo esc_html( $level['name'] ); ?></strong><br />
-                                    <small><?php echo esc_html( implode( ' • ', array_map( 'wp_strip_all_tags', (array) $level['benefits'] ) ) ); ?></small>
+                                    <small><?php echo esc_html( implode( ' • ', $benefits ) ); ?></small>
                                 </td>
                                 <td><?php echo esc_html( $this->format_amount( $level['fee'], $currency ) ); ?></td>
                                 <td><?php echo esc_html( $this->format_amount( $level['commission_direct'], $currency ) ); ?></td>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.2
+Stable tag: 0.3.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -47,6 +47,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.3 =
+* Prevent a fatal error on the settings screen when membership level option data is stored as strings instead of arrays.
+
 = 0.3.2 =
 * Fix a fatal error on `init` by making the sponsor capture callback public so it can be used as an action hook.
 
@@ -67,6 +70,9 @@ Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (
 (See previous entries for earlier releases.)
 
 == Upgrade Notice ==
+= 0.3.3 =
+Prevents a fatal error on the TCN Platform settings screen when membership levels are misconfigured.
+
 = 0.3.2 =
 Addresses a fatal error thrown on sites hooking into sponsor capture during `init`.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.2
+ * Version:           0.3.3
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.2' );
+define( 'TCN_PLATFORM_VERSION', '0.3.3' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- guard the settings page membership level table against malformed option data to prevent fatal errors
- sanitize rendered benefits strings before display
- bump the plugin to version 0.3.3 and document the release notes

## Testing
- php -l includes/Admin/SettingsPage.php

------
https://chatgpt.com/codex/tasks/task_e_68e0dc012aa483278ffb82947e787942