### PR TITLE
Restrict membership product seeding to canonical tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.4
+- Ensure the membership product seeder only creates Blue/Gold/Platinum/Black tiers even if legacy configuration data contains stray levels.
+
 ### 0.3.3
 - Prevent a fatal error on the admin settings screen when membership level option data is unexpectedly stored as strings.
 

--- a/includes/Membership/MembershipModule.php
+++ b/includes/Membership/MembershipModule.php
@@ -597,14 +597,11 @@ class MembershipModule {
             return;
         }
 
-        $levels          = Options::get_levels();
-        $default_levels  = Options::default_levels();
+        $levels         = Options::get_levels();
+        $default_levels = Options::default_levels();
 
-        foreach ( $levels as $key => $level ) {
-            $level_defaults = $default_levels[ $key ] ?? array(
-                'name' => is_string( $key ) ? ucwords( str_replace( '_', ' ', $key ) ) : __( 'Membership', 'tcnapp-connector' ),
-                'fee'  => 0,
-            );
+        foreach ( $default_levels as $key => $level_defaults ) {
+            $level = $levels[ $key ] ?? $level_defaults;
 
             if ( ! is_array( $level ) ) {
                 $level = $level_defaults;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.3
+Stable tag: 0.3.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -47,6 +47,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.4 =
+* Ensure membership product seeding only creates the Blue, Gold, Platinum, and Black tiers even when legacy options contain stray entries.
+
 = 0.3.3 =
 * Prevent a fatal error on the settings screen when membership level option data is stored as strings instead of arrays.
 
@@ -70,6 +73,9 @@ Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (
 (See previous entries for earlier releases.)
 
 == Upgrade Notice ==
+= 0.3.4 =
+Restricts auto-generated membership products to the official Blue/Gold/Platinum/Black tiers when old configuration data includes unexpected entries.
+
 = 0.3.3 =
 Prevents a fatal error on the TCN Platform settings screen when membership levels are misconfigured.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.3
+ * Version:           0.3.4
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.3' );
+define( 'TCN_PLATFORM_VERSION', '0.3.4' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- scope membership product seeding to the default Blue, Gold, Platinum, and Black tiers so stray option values no longer create extra products
- bump the plugin version to 0.3.4 and document the change in both readme files

## Testing
- php -l includes/Membership/MembershipModule.php

------
https://chatgpt.com/codex/tasks/task_e_68e0ddc3010c832781b816ef6c96f66f