### PR TITLE
Add automatic GitHub update checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.5
+- Integrate Plugin Update Checker so WordPress installs can detect GitHub releases automatically.
+
 ### 0.3.4
 - Ensure the membership product seeder only creates Blue/Gold/Platinum/Black tiers even if legacy configuration data contains stray levels.
 

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -6,6 +6,7 @@ use TCN\Platform\Admin\SettingsPage;
 use TCN\Platform\Auth\PasswordLoginService;
 use TCN\Platform\Membership\MembershipModule;
 use TCN\Platform\Support\Modules;
+use TCN\Platform\Support\Updater;
 
 class Plugin {
     /**
@@ -41,6 +42,7 @@ class Plugin {
 
     protected function register_services(): void {
         $this->services[] = new MembershipModule( $this->modules );
+        $this->services[] = new Updater();
 
         if ( $this->modules->is_enabled( Modules::MODULE_AUTH_LOGIN ) ) {
             $this->services[] = new PasswordLoginService();

--- a/includes/Support/Updater.php
+++ b/includes/Support/Updater.php
@@ -1,0 +1,40 @@
+<?php
+namespace TCN\Platform\Support;
+
+use YahnisElsts\PluginUpdateChecker\v5\PucFactory;
+
+class Updater {
+    /**
+     * Register the plugin update checker integration.
+     */
+    public function register(): void {
+        if ( ! class_exists( PucFactory::class ) ) {
+            return;
+        }
+
+        $repository_url = defined( 'TCN_PLATFORM_UPDATE_REPOSITORY_URL' )
+            ? TCN_PLATFORM_UPDATE_REPOSITORY_URL
+            : 'https://github.com/GeorgeWebDevCy/tcnapp-connector/';
+        $repository_url = \apply_filters( 'tcn_platform_update_repository_url', $repository_url );
+
+        $branch = defined( 'TCN_PLATFORM_UPDATE_REPOSITORY_BRANCH' )
+            ? TCN_PLATFORM_UPDATE_REPOSITORY_BRANCH
+            : 'main';
+        $branch = \apply_filters( 'tcn_platform_update_repository_branch', $branch );
+
+        $update_checker = PucFactory::buildUpdateChecker(
+            $repository_url,
+            \TCN_PLATFORM_PLUGIN_FILE,
+            'tcnapp-connector'
+        );
+
+        if ( is_string( $branch ) && '' !== $branch ) {
+            $update_checker->setBranch( $branch );
+        }
+
+        $vcs_api = $update_checker->getVcsApi();
+        if ( is_object( $vcs_api ) && method_exists( $vcs_api, 'enableReleaseAssets' ) ) {
+            $vcs_api->enableReleaseAssets();
+        }
+    }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.4
+Stable tag: 0.3.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -47,6 +47,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.5 =
+* Wire the plugin to the public GitHub repository via Plugin Update Checker so WordPress can discover releases automatically.
+
 = 0.3.4 =
 * Ensure membership product seeding only creates the Blue, Gold, Platinum, and Black tiers even when legacy options contain stray entries.
 
@@ -73,6 +76,9 @@ Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (
 (See previous entries for earlier releases.)
 
 == Upgrade Notice ==
+= 0.3.5 =
+Enables automatic updates through the GitHub repository using the bundled Plugin Update Checker integration.
+
 = 0.3.4 =
 Restricts auto-generated membership products to the official Blue/Gold/Platinum/Black tiers when old configuration data includes unexpected entries.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.4
+ * Version:           0.3.5
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,10 +16,14 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.4' );
+define( 'TCN_PLATFORM_VERSION', '0.3.5' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+    require_once __DIR__ . '/vendor/autoload.php';
+}
 
 require_once TCN_PLATFORM_PLUGIN_DIR . 'includes/Autoloader.php';
 TCN\Platform\Autoloader::register();


### PR DESCRIPTION
## Summary
- load Composer's autoloader and register a new updater service
- integrate plugin-update-checker with the public GitHub repository and expose URL/branch overrides
- document the new automatic update support and bump the plugin version to 0.3.5

## Testing
- php -l includes/Support/Updater.php
- php -l tcnapp-connector.php

------
https://chatgpt.com/codex/tasks/task_e_68e0e13f27148327ba73c6bafaa85e7e