### PR TITLE
Document TCNApp pricing alignment and update defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ These settings persist in the `gn_login_api_settings` option. A compatibility sh
 - Adds **MLM Dashboard** and **MLM Genealogy** entries to WooCommerce My Account navigation (`/my-account/tcn-member-dashboard/`, `/my-account/tcn-genealogy/`).
 - REST endpoints under `tcn-mlm/v1/*` expose member profiles, genealogy trees, and commission summaries (`/member`, `/genealogy`, `/commissions`) that power the TCNApp dashboards.
 
+## 📱 TCNApp Mobile Alignment
+
+TCN Platform keeps the WooCommerce catalogue aligned with the membership products consumed by the TCNApp mobile client. Default pricing mirrors the app’s subscription matrix so the web checkout and in-app upsells stay consistent:
+
+| Tier | Mobile Label | Default Price (USD) | Notes |
+| ---- | ------------- | ------------------- | ----- |
+| Blue | Customer | $0 | Baseline storefront access with no commissions. |
+| Gold | Affiliate | $149 | Unlocks direct recruitment commissions and eligibility for passive rewards after two directs. |
+| Platinum | Leader | $399 | Higher direct commission rate and first-level passive income. |
+| Black | Elite | $899 | Top-tier commission multipliers plus leadership resources mirrored in the app. |
+
+Sites can override these amounts from **TCN Platform → Membership Defaults**, but the seeded WooCommerce products and mobile catalogue remain in sync by default.
+
 ## 🔑 Password Login API Endpoints
 
 All endpoints live under `wp-json/gn/v1`:
@@ -77,6 +90,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 - Namespaced PHP classes live under `includes/` and autoload via `includes/Autoloader.php`.
 
 ## 📝 Release Notes
+
+### 0.3.6
+- Document TCNApp mobile pricing alignment and update default membership fees to match the current catalogue.
 
 ### 0.3.5
 - Integrate Plugin Update Checker so WordPress installs can detect GitHub releases automatically.

--- a/includes/Support/Options.php
+++ b/includes/Support/Options.php
@@ -88,7 +88,7 @@ class Options {
                 'name'               => __( 'Gold', 'tcnapp-connector' ),
                 'slug'               => 'gold',
                 'rank'               => 1,
-                'fee'                => 200,
+                'fee'                => 149,
                 'commission_direct'  => 50,
                 'commission_passive' => 10,
                 'benefits'           => array(
@@ -100,7 +100,7 @@ class Options {
                 'name'               => __( 'Platinum', 'tcnapp-connector' ),
                 'slug'               => 'platinum',
                 'rank'               => 2,
-                'fee'                => 500,
+                'fee'                => 399,
                 'commission_direct'  => 80,
                 'commission_passive' => 20,
                 'benefits'           => array(
@@ -112,7 +112,7 @@ class Options {
                 'name'               => __( 'Black', 'tcnapp-connector' ),
                 'slug'               => 'black',
                 'rank'               => 3,
-                'fee'                => 1000,
+                'fee'                => 899,
                 'commission_direct'  => 120,
                 'commission_passive' => 40,
                 'benefits'           => array(

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.5
+Stable tag: 0.3.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -33,6 +33,15 @@ Configure modules under **TCN Platform → Modules**. The Membership & MLM modul
 * `/wp-json/gn/v1/register`, `/forgot-password`, `/reset-password`, and `/change-password` wrap WordPress flows with opinionated validation and neutral responses to avoid account enumeration.
 * Member dashboards consume `/wp-json/tcn-mlm/v1/member`, `/genealogy`, and `/commissions` to populate the app UI.
 
+TCNApp’s membership catalogue currently surfaces the following pricing, which the plugin seeds into WooCommerce products so the web store and mobile upsells remain aligned:
+
+* **Blue (Customer)** – $0: storefront access without commission eligibility.
+* **Gold (Affiliate)** – $149: unlocks direct recruitment commissions and the ability to earn passive rewards after two direct recruits.
+* **Platinum (Leader)** – $399: increases direct commission rates and pays first-level passive income.
+* **Black (Elite)** – $899: top-tier commission multipliers and leadership enablement perks as mirrored in the mobile experience.
+
+Adjust these figures from **TCN Platform → Membership Defaults** if your deployment uses bespoke pricing; the plugin will continue syncing WooCommerce products and the TCNApp catalogue defaults unless changed.
+
 == Frequently Asked Questions ==
 = How do automatic updates work? =
 The bundled [Plugin Update Checker](https://github.com/YahnisElsts/plugin-update-checker) points to this GitHub repository. Override the repository URL or branch using the `TCN_PLATFORM_UPDATE_REPOSITORY_URL`, `TCN_PLATFORM_UPDATE_REPOSITORY_BRANCH` constants, or their filter counterparts.
@@ -47,6 +56,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.6 =
+* Document the TCNApp mobile pricing matrix and update default membership fees to match the app catalogue.
+
 = 0.3.5 =
 * Wire the plugin to the public GitHub repository via Plugin Update Checker so WordPress can discover releases automatically.
 
@@ -76,6 +88,9 @@ Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (
 (See previous entries for earlier releases.)
 
 == Upgrade Notice ==
+= 0.3.6 =
+Aligns default membership pricing with the latest TCNApp catalogue and documents the mobile plan matrix.
+
 = 0.3.5 =
 Enables automatic updates through the GitHub repository using the bundled Plugin Update Checker integration.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.5
+ * Version:           0.3.6
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.5' );
+define( 'TCN_PLATFORM_VERSION', '0.3.6' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- document how the plugin mirrors the TCNApp mobile membership catalogue and list the current plan pricing
- update the default membership fees to the new amounts and bump the plugin version to 0.3.6

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0e33e23508327a56d759478959375