### PR TITLE
Align MLM pricing with THB programme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ These settings persist in the `gn_login_api_settings` option. A compatibility sh
 
 ## 📱 TCNApp Mobile Alignment
 
-TCN Platform keeps the WooCommerce catalogue aligned with the membership products consumed by the TCNApp mobile client. Default pricing mirrors the app’s subscription matrix so the web checkout and in-app upsells stay consistent:
+TCN Platform keeps the WooCommerce catalogue aligned with the membership products consumed by the TCNApp mobile client. Default pricing now mirrors the THB membership matrix so the web checkout and in-app upsells stay consistent:
 
-| Tier | Mobile Label | Default Price (USD) | Notes |
+| Tier | Mobile Label | Default Price (THB) | Notes |
 | ---- | ------------- | ------------------- | ----- |
-| Blue | Customer | $0 | Baseline storefront access with no commissions. |
-| Gold | Affiliate | $149 | Unlocks direct recruitment commissions and eligibility for passive rewards after two directs. |
-| Platinum | Leader | $399 | Higher direct commission rate and first-level passive income. |
-| Black | Elite | $899 | Top-tier commission multipliers plus leadership resources mirrored in the app. |
+| Blue | Customer | ฿0 | Baseline storefront access with no commissions. |
+| Gold | Affiliate | ฿500 | Earns THB125 on each direct recruit and unlocks passive rewards after two directs. |
+| Platinum | Leader | ฿1,200 | Awards THB250 on new directs while maintaining THB125 passive overrides. |
+| Black | Elite | ฿2,000 | Leadership renewal tier with continued THB125 passive income from downline activity. |
 
 Sites can override these amounts from **TCN Platform → Membership Defaults**, but the seeded WooCommerce products and mobile catalogue remain in sync by default.
 
@@ -90,6 +90,11 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 - Namespaced PHP classes live under `includes/` and autoload via `includes/Autoloader.php`.
 
 ## 📝 Release Notes
+
+### 0.3.7
+- Align default membership pricing with the THB consumer network matrix, including commission overrides for Platinum/Black sponsors.
+- Track total network size for auto-upgrades so Platinum members advance to Black once their active downline reaches two people.
+- Update docs and option defaults to reflect THB currency throughout the plugin.
 
 ### 0.3.6
 - Document TCNApp mobile pricing alignment and update default membership fees to match the current catalogue.

--- a/architecture.md
+++ b/architecture.md
@@ -24,6 +24,7 @@ TCN Platform combines the WooCommerce membership/MLM stack with the GN Password 
   - `_tcn_sponsor_id` (int, user ID of direct sponsor)
   - `_tcn_network_owner` (int, root of the member's current network)
   - `_tcn_direct_recruits` (int, cached count for upgrade checks)
+  - `_tcn_network_size` (int, total members in the active downline used for Platinum → Black promotions)
   - `_gn_login_token_*` (JSON payloads for one-time token logins; created and deleted dynamically)
   - `_gn_password_api_reset_code` (hashed reset code bundle)
 - **Options**

--- a/includes/Membership/MembershipModule.php
+++ b/includes/Membership/MembershipModule.php
@@ -377,7 +377,7 @@ class MembershipModule {
         if ( $sponsor_id ) {
             update_user_meta( $user_id, '_tcn_sponsor_id', $sponsor_id );
             $this->update_direct_recruits( $sponsor_id );
-            $this->maybe_handle_auto_upgrade( $sponsor_id );
+            $this->maybe_handle_ancestor_upgrades( $sponsor_id );
         }
     }
 
@@ -391,6 +391,7 @@ class MembershipModule {
         if ( $cookie ) {
             update_user_meta( $user_id, '_tcn_sponsor_id', $cookie );
             $this->update_direct_recruits( $cookie );
+            $this->maybe_handle_ancestor_upgrades( $cookie );
             return;
         }
 
@@ -398,6 +399,7 @@ class MembershipModule {
         if ( ! empty( $general['default_sponsor'] ) ) {
             update_user_meta( $user_id, '_tcn_sponsor_id', (int) $general['default_sponsor'] );
             $this->update_direct_recruits( (int) $general['default_sponsor'] );
+            $this->maybe_handle_ancestor_upgrades( (int) $general['default_sponsor'] );
         }
     }
 
@@ -412,15 +414,40 @@ class MembershipModule {
 
         $sponsor_id = (int) get_user_meta( $member_id, '_tcn_sponsor_id', true );
         if ( $sponsor_id ) {
-            $this->insert_commission( $sponsor_id, $member_id, $order_id, 'direct', (float) $levels[ $level_key ]['commission_direct'], $currency );
+            $direct_amount = $this->calculate_direct_commission_amount( $level_key, $sponsor_id, $levels );
+            if ( $direct_amount > 0 ) {
+                $this->insert_commission( $sponsor_id, $member_id, $order_id, 'direct', $direct_amount, $currency );
+            }
             $this->update_direct_recruits( $sponsor_id );
-            $this->maybe_handle_auto_upgrade( $sponsor_id );
+            $this->maybe_handle_ancestor_upgrades( $sponsor_id );
 
             $upline_id = (int) get_user_meta( $sponsor_id, '_tcn_sponsor_id', true );
-            if ( $upline_id && ! empty( $levels[ $level_key ]['commission_passive'] ) ) {
-                $this->insert_commission( $upline_id, $member_id, $order_id, 'passive', (float) $levels[ $level_key ]['commission_passive'], $currency );
+            $passive_amount = isset( $levels[ $level_key ]['commission_passive'] ) ? (float) $levels[ $level_key ]['commission_passive'] : 0.0;
+            if ( $upline_id && $passive_amount > 0 ) {
+                $this->insert_commission( $upline_id, $member_id, $order_id, 'passive', $passive_amount, $currency );
             }
         }
+    }
+
+    protected function calculate_direct_commission_amount( string $level_key, int $sponsor_id, array $levels ): float {
+        if ( empty( $levels[ $level_key ] ) ) {
+            return 0.0;
+        }
+
+        $level         = $levels[ $level_key ];
+        $base_amount   = isset( $level['commission_direct'] ) ? (float) $level['commission_direct'] : 0.0;
+        $sponsor_level = get_user_meta( $sponsor_id, '_tcn_membership_level', true );
+        if ( ! $sponsor_level ) {
+            $sponsor_level = 'blue';
+        }
+
+        if ( ! empty( $level['commission_direct_overrides'] ) && is_array( $level['commission_direct_overrides'] ) ) {
+            if ( isset( $level['commission_direct_overrides'][ $sponsor_level ] ) ) {
+                $base_amount = (float) $level['commission_direct_overrides'][ $sponsor_level ];
+            }
+        }
+
+        return (float) apply_filters( 'tcn_mlm_direct_commission_amount', $base_amount, $level_key, $sponsor_id, $sponsor_level, $levels );
     }
 
     protected function insert_commission( int $sponsor_id, int $member_id, int $order_id, string $level, float $amount, string $currency ): void {
@@ -443,14 +470,25 @@ class MembershipModule {
         );
     }
 
+    protected function maybe_handle_ancestor_upgrades( int $user_id ): void {
+        $current = $user_id;
+        $visited = array();
+
+        while ( $current && ! in_array( $current, $visited, true ) ) {
+            $visited[] = $current;
+            $this->maybe_handle_auto_upgrade( $current );
+            $current = (int) get_user_meta( $current, '_tcn_sponsor_id', true );
+        }
+    }
+
     protected function maybe_handle_auto_upgrade( int $user_id ): void {
         $current = get_user_meta( $user_id, '_tcn_membership_level', true );
-        $levels  = Options::get_levels();
         $recruits = (int) get_user_meta( $user_id, '_tcn_direct_recruits', true );
+        $network  = (int) get_user_meta( $user_id, '_tcn_network_size', true );
 
         if ( 'gold' === $current && $recruits >= 2 ) {
             $this->set_membership_level( $user_id, 'platinum' );
-        } elseif ( 'platinum' === $current && $recruits >= 2 ) {
+        } elseif ( 'platinum' === $current && $network >= 2 ) {
             $this->set_membership_level( $user_id, 'black' );
         } elseif ( empty( $current ) ) {
             $this->set_membership_level( $user_id, 'blue' );
@@ -473,14 +511,63 @@ class MembershipModule {
     }
 
     protected function update_direct_recruits( int $user_id ): void {
+        if ( $user_id <= 0 ) {
+            return;
+        }
+
+        $this->refresh_network_metrics( $user_id, array() );
+    }
+
+    protected function refresh_network_metrics( int $user_id, array $visited ): void {
+        if ( $user_id <= 0 || in_array( $user_id, $visited, true ) ) {
+            return;
+        }
+
+        $visited[] = $user_id;
+
         $recruits = count( get_users( array(
-            'fields'    => 'ids',
-            'meta_key'  => '_tcn_sponsor_id',
-            'meta_value'=> $user_id,
-            'number'    => -1,
+            'fields'     => 'ids',
+            'meta_key'   => '_tcn_sponsor_id',
+            'meta_value' => $user_id,
+            'number'     => -1,
         ) ) );
 
         update_user_meta( $user_id, '_tcn_direct_recruits', (int) $recruits );
+        update_user_meta( $user_id, '_tcn_network_size', (int) $this->count_network_members( $user_id ) );
+
+        $sponsor_id = (int) get_user_meta( $user_id, '_tcn_sponsor_id', true );
+        if ( $sponsor_id > 0 ) {
+            $this->refresh_network_metrics( $sponsor_id, $visited );
+        }
+    }
+
+    protected function count_network_members( int $user_id, array $visited = array() ): int {
+        if ( $user_id <= 0 || in_array( $user_id, $visited, true ) ) {
+            return 0;
+        }
+
+        $visited[] = $user_id;
+
+        $children = get_users( array(
+            'fields'     => 'ids',
+            'meta_key'   => '_tcn_sponsor_id',
+            'meta_value' => $user_id,
+            'number'     => -1,
+        ) );
+
+        $count = 0;
+
+        foreach ( $children as $child_id ) {
+            $child_id = (int) $child_id;
+            if ( in_array( $child_id, $visited, true ) ) {
+                continue;
+            }
+
+            $count++;
+            $count += $this->count_network_members( $child_id, $visited );
+        }
+
+        return $count;
     }
 
     protected function build_genealogy_tree( int $user_id, int $depth ): array {

--- a/includes/Support/Options.php
+++ b/includes/Support/Options.php
@@ -88,36 +88,43 @@ class Options {
                 'name'               => __( 'Gold', 'tcnapp-connector' ),
                 'slug'               => 'gold',
                 'rank'               => 1,
-                'fee'                => 149,
-                'commission_direct'  => 50,
-                'commission_passive' => 10,
+                'fee'                => 500,
+                'commission_direct'  => 125,
+                'commission_passive' => 125,
+                'commission_direct_overrides' => array(
+                    'platinum' => 250,
+                    'black'    => 250,
+                ),
                 'benefits'           => array(
-                    __( 'Earn direct commissions on recruits', 'tcnapp-connector' ),
-                    __( 'Eligible for passive commissions after two direct recruits', 'tcnapp-connector' ),
+                    __( 'Earn THB125 on each direct recruit', 'tcnapp-connector' ),
+                    __( 'Unlock passive income after two recruits', 'tcnapp-connector' ),
                 ),
             ),
             'platinum' => array(
                 'name'               => __( 'Platinum', 'tcnapp-connector' ),
                 'slug'               => 'platinum',
                 'rank'               => 2,
-                'fee'                => 399,
-                'commission_direct'  => 80,
-                'commission_passive' => 20,
+                'fee'                => 1200,
+                'commission_direct'  => 250,
+                'commission_passive' => 125,
+                'commission_direct_overrides' => array(
+                    'black' => 250,
+                ),
                 'benefits'           => array(
-                    __( 'Higher direct commissions', 'tcnapp-connector' ),
-                    __( 'Passive commissions from first level downline', 'tcnapp-connector' ),
+                    __( 'Earn THB250 on each direct recruit', 'tcnapp-connector' ),
+                    __( 'Passive commissions continue from first downline level', 'tcnapp-connector' ),
                 ),
             ),
             'black'    => array(
                 'name'               => __( 'Black', 'tcnapp-connector' ),
                 'slug'               => 'black',
                 'rank'               => 3,
-                'fee'                => 899,
-                'commission_direct'  => 120,
-                'commission_passive' => 40,
+                'fee'                => 2000,
+                'commission_direct'  => 250,
+                'commission_passive' => 125,
                 'benefits'           => array(
-                    __( 'Maximum commission tier', 'tcnapp-connector' ),
-                    __( 'Priority support and leadership resources', 'tcnapp-connector' ),
+                    __( 'Leadership status with the highest renewal fee', 'tcnapp-connector' ),
+                    __( 'Continues earning THB125 from downline activity', 'tcnapp-connector' ),
                 ),
             ),
         );
@@ -128,7 +135,7 @@ class Options {
      */
     public static function default_general_settings(): array {
         return array(
-            'currency'        => 'USD',
+            'currency'        => 'THB',
             'default_sponsor' => 0,
         );
     }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.6
+Stable tag: 0.3.7
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -33,12 +33,12 @@ Configure modules under **TCN Platform → Modules**. The Membership & MLM modul
 * `/wp-json/gn/v1/register`, `/forgot-password`, `/reset-password`, and `/change-password` wrap WordPress flows with opinionated validation and neutral responses to avoid account enumeration.
 * Member dashboards consume `/wp-json/tcn-mlm/v1/member`, `/genealogy`, and `/commissions` to populate the app UI.
 
-TCNApp’s membership catalogue currently surfaces the following pricing, which the plugin seeds into WooCommerce products so the web store and mobile upsells remain aligned:
+TCNApp’s membership catalogue currently surfaces the following THB pricing, which the plugin seeds into WooCommerce products so the web store and mobile upsells remain aligned:
 
-* **Blue (Customer)** – $0: storefront access without commission eligibility.
-* **Gold (Affiliate)** – $149: unlocks direct recruitment commissions and the ability to earn passive rewards after two direct recruits.
-* **Platinum (Leader)** – $399: increases direct commission rates and pays first-level passive income.
-* **Black (Elite)** – $899: top-tier commission multipliers and leadership enablement perks as mirrored in the mobile experience.
+* **Blue (Customer)** – ฿0: storefront access without commission eligibility.
+* **Gold (Affiliate)** – ฿500: earns THB125 on each direct recruit and unlocks passive rewards after two direct recruits.
+* **Platinum (Leader)** – ฿1,200: awards THB250 on new directs while maintaining THB125 passive overrides.
+* **Black (Elite)** – ฿2,000: leadership renewal tier with continued THB125 passive income from downline activity.
 
 Adjust these figures from **TCN Platform → Membership Defaults** if your deployment uses bespoke pricing; the plugin will continue syncing WooCommerce products and the TCNApp catalogue defaults unless changed.
 
@@ -56,6 +56,11 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.7 =
+* Align default membership fees with the updated THB consumer network programme and introduce commission overrides for Platinum/Black sponsors.
+* Recalculate cached network sizes so Platinum members promote to Black once their active downline reaches two people.
+* Default plugin currency and documentation to THB to match the membership catalogue.
+
 = 0.3.6 =
 * Document the TCNApp mobile pricing matrix and update default membership fees to match the app catalogue.
 
@@ -88,6 +93,9 @@ Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (
 (See previous entries for earlier releases.)
 
 == Upgrade Notice ==
+= 0.3.7 =
+Updates membership pricing to the THB consumer network matrix, recalculates network size-driven upgrades, and refreshes documentation.
+
 = 0.3.6 =
 Aligns default membership pricing with the latest TCNApp catalogue and documents the mobile plan matrix.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.6
+ * Version:           0.3.7
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.6' );
+define( 'TCN_PLATFORM_VERSION', '0.3.7' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- switch membership defaults to the THB pricing matrix, including sponsor-level commission overrides and THB currency defaults
- recalculate cached direct/network metrics so Platinum upgrades to Black once the active network reaches two members and propagate ancestor upgrades
- refresh docs/readmes for the new pricing model and bump the plugin to version 0.3.7

## Testing
- php -l includes/Membership/MembershipModule.php
- php -l includes/Support/Options.php
- php -l tcnapp-connector.php

------
https://chatgpt.com/codex/tasks/task_e_68e0e55c370083279b2a1e307e683e13