### PR TITLE
Fix admin membership levels display and release 0.3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.8
+- Ensure membership level defaults repopulate missing fee and commission fields so the admin overview table shows accurate values.
+
 ### 0.3.7
 - Align default membership pricing with the THB consumer network matrix, including commission overrides for Platinum/Black sponsors.
 - Track total network size for auto-upgrades so Platinum members advance to Black once their active downline reaches two people.

--- a/includes/Support/Options.php
+++ b/includes/Support/Options.php
@@ -29,7 +29,28 @@ class Options {
             $levels = array();
         }
 
-        return wp_parse_args( $levels, self::default_levels() );
+        $defaults = self::default_levels();
+
+        $normalized = array();
+        foreach ( $levels as $key => $level ) {
+            if ( ! is_array( $level ) ) {
+                $level = array();
+            }
+
+            $base = $defaults[ $key ] ?? array(
+                'name'               => '',
+                'slug'               => $key,
+                'rank'               => 0,
+                'fee'                => 0,
+                'commission_direct'  => 0,
+                'commission_passive' => 0,
+                'benefits'           => array(),
+            );
+
+            $normalized[ $key ] = wp_parse_args( $level, $base );
+        }
+
+        return array_replace( $defaults, $normalized );
     }
 
     public static function update_levels( array $levels ): void {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.7
+Stable tag: 0.3.8
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -56,6 +56,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.8 =
+* Ensure membership level defaults backfill missing pricing/commission values so the admin summary table always renders the correct data.
+
 = 0.3.7 =
 * Align default membership fees with the updated THB consumer network programme and introduce commission overrides for Platinum/Black sponsors.
 * Recalculate cached network sizes so Platinum members promote to Black once their active downline reaches two people.

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.7
+ * Version:           0.3.8
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.7' );
+define( 'TCN_PLATFORM_VERSION', '0.3.8' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- normalize stored membership levels against defaults so missing fee/commission fields render correctly in the admin table
- bump the plugin version to 0.3.8 and document the change in both readme files

## Testing
- php -l includes/Support/Options.php

------
https://chatgpt.com/codex/tasks/task_e_68e0e87a6d308327aa218d9af409fb65