### PR TITLE
Normalise membership level slugs

### DIFF
--- a/includes/Support/Options.php
+++ b/includes/Support/Options.php
@@ -33,13 +33,26 @@ class Options {
 
         $normalized = array();
         foreach ( $levels as $key => $level ) {
-            if ( ! is_array( $level ) ) {
+            if ( is_string( $level ) ) {
+                $level = array( 'name' => $level );
+            } elseif ( ! is_array( $level ) ) {
                 $level = array();
             }
 
-            $base = $defaults[ $key ] ?? array(
+            $slug = '';
+            if ( isset( $level['slug'] ) && is_string( $level['slug'] ) ) {
+                $slug = sanitize_key( $level['slug'] );
+            } elseif ( is_string( $key ) && '' !== $key ) {
+                $slug = sanitize_key( $key );
+            }
+
+            if ( '' === $slug ) {
+                continue;
+            }
+
+            $base = $defaults[ $slug ] ?? array(
                 'name'               => '',
-                'slug'               => $key,
+                'slug'               => $slug,
                 'rank'               => 0,
                 'fee'                => 0,
                 'commission_direct'  => 0,
@@ -47,7 +60,8 @@ class Options {
                 'benefits'           => array(),
             );
 
-            $normalized[ $key ] = wp_parse_args( $level, $base );
+            $level['slug']     = $slug;
+            $normalized[ $slug ] = wp_parse_args( $level, $base );
         }
 
         return array_replace( $defaults, $normalized );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.8
+Stable tag: 0.3.9
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -56,6 +56,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.9 =
+* Normalise membership level slugs when loading options so the admin summary avoids rendering duplicate blank rows.
+
 = 0.3.8 =
 * Ensure membership level defaults backfill missing pricing/commission values so the admin summary table always renders the correct data.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.8
+ * Version:           0.3.9
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.8' );
+define( 'TCN_PLATFORM_VERSION', '0.3.9' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- normalise membership level slugs when loading membership options so duplicate numeric keys do not render empty rows in the admin table
- ensure each level retains a sanitised slug and ignore entries without a usable key
- bump the plugin version to 0.3.9 and update the readme changelog

## Testing
- php -l includes/Support/Options.php

------
https://chatgpt.com/codex/tasks/task_e_68e0eabca7088327a3d84d5c54484c5c