### PR TITLE
Sync membership summary with WooCommerce pricing

### DIFF
--- a/includes/Support/Options.php
+++ b/includes/Support/Options.php
@@ -64,7 +64,12 @@ class Options {
             $normalized[ $slug ] = wp_parse_args( $level, $base );
         }
 
-        return array_replace( $defaults, $normalized );
+        $levels = array_replace( $defaults, $normalized );
+
+        // Only expose the official tiers even if legacy data introduces stray keys.
+        $levels = array_intersect_key( $levels, $defaults );
+
+        return self::apply_membership_product_fees( $levels );
     }
 
     public static function update_levels( array $levels ): void {
@@ -101,6 +106,69 @@ class Options {
 
     public static function update_login_settings( array $settings ): void {
         update_option( self::OPTION_LOGIN_SETTINGS, wp_parse_args( $settings, self::default_login_settings() ) );
+    }
+
+    /**
+     * Overlay membership fees from WooCommerce products so the admin summary
+     * reflects the current catalogue configuration.
+     *
+     * @param array<string, array<string, mixed>> $levels
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    protected static function apply_membership_product_fees( array $levels ): array {
+        if ( empty( $levels ) || ! function_exists( 'wc_get_products' ) ) {
+            return $levels;
+        }
+
+        $products = wc_get_products(
+            array(
+                'limit'      => -1,
+                'status'     => array( 'publish', 'pending', 'draft' ),
+                'meta_query' => array(
+                    array(
+                        'key'     => '_tcn_membership_level',
+                        'compare' => 'EXISTS',
+                    ),
+                ),
+            )
+        );
+
+        if ( empty( $products ) ) {
+            return $levels;
+        }
+
+        foreach ( $products as $product ) {
+            $level_key = $product->get_meta( '_tcn_membership_level' );
+
+            if ( ! is_string( $level_key ) ) {
+                continue;
+            }
+
+            $level_key = sanitize_key( $level_key );
+
+            if ( '' === $level_key || ! isset( $levels[ $level_key ] ) ) {
+                continue;
+            }
+
+            $price = $product->get_price( 'edit' );
+
+            if ( '' === $price ) {
+                $price = $product->get_regular_price( 'edit' );
+            }
+
+            if ( '' === $price ) {
+                $price = 0;
+            }
+
+            if ( function_exists( 'wc_format_decimal' ) ) {
+                $price = wc_format_decimal( $price );
+            }
+
+            $levels[ $level_key ]['fee'] = (float) $price;
+        }
+
+        return $levels;
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.9
+Stable tag: 0.3.10
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -56,6 +56,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.10 =
+* Sync the membership summary table with WooCommerce product pricing and suppress stray legacy tiers.
+
 = 0.3.9 =
 * Normalise membership level slugs when loading options so the admin summary avoids rendering duplicate blank rows.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.9
+ * Version:           0.3.10
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.9' );
+define( 'TCN_PLATFORM_VERSION', '0.3.10' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- overlay membership level fees with current WooCommerce product pricing and filter out stray legacy tiers
- bump the plugin version to 0.3.10 and document the change in the readme

## Testing
- php -l includes/Support/Options.php

------
https://chatgpt.com/codex/tasks/task_e_68e0ec5a4de08327aa56fac836cb63eb