### PR TITLE
Add activity log admin screen and monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Toggle modules under **TCN Platform → Modules**. The Membership & MLM module s
 
 These settings persist in the `gn_login_api_settings` option. A compatibility shim keeps `GN_Password_Login_API` usable for legacy code.
 
+## 📊 Activity Monitoring
+
+- Review REST API usage and plugin events from **TCN Platform → Activity Log**.
+- The log captures calls to `gn/v1/*` and `tcn-mlm/v1/*` namespaces, redacting sensitive payload fields like passwords and tokens.
+- Activation, deactivation, settings changes, and manual log clears are also recorded so administrators can audit configuration changes.
+
 ## 💼 Membership & MLM Highlights
 
 - Seeds Blue/Gold/Platinum/Black WooCommerce products on activation, maintaining pricing alignment with the mobile catalogue.

--- a/admin/css/tcn-platform-admin.css
+++ b/admin/css/tcn-platform-admin.css
@@ -55,3 +55,56 @@
     padding: 12px;
     background: #f0f6fc;
 }
+
+.tcn-platform-logs .description {
+    margin-bottom: 1rem;
+}
+
+.tcn-platform-log-actions {
+    margin: 1rem 0;
+}
+
+.tcn-platform-log-table td,
+.tcn-platform-log-table th {
+    vertical-align: top;
+}
+
+.tcn-platform-log-list {
+    margin: 0;
+    padding-left: 18px;
+}
+
+.tcn-platform-log-key {
+    display: inline-block;
+    min-width: 140px;
+    font-weight: 600;
+}
+
+.tcn-platform-log-pre {
+    background: #f6f7f7;
+    border-radius: 4px;
+    padding: 8px 10px;
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.tcn-platform-log-boolean.is-true {
+    color: #0f8c1a;
+    font-weight: 600;
+}
+
+.tcn-platform-log-boolean.is-false {
+    color: #b52727;
+    font-weight: 600;
+}
+
+.tcn-platform-log-number,
+.tcn-platform-log-text {
+    font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
+}
+
+.tcn-platform-log-empty {
+    color: #64748b;
+    font-style: italic;
+}

--- a/includes/Admin/LogPage.php
+++ b/includes/Admin/LogPage.php
@@ -1,0 +1,211 @@
+<?php
+namespace TCN\Platform\Admin;
+
+use TCN\Platform\Support\Logger;
+
+use function __;
+use function add_query_arg;
+use function add_submenu_page;
+use function admin_url;
+use function current_user_can;
+use function date_i18n;
+use function esc_html;
+use function esc_html__;
+use function esc_html_e;
+use function esc_url;
+use function get_option;
+use function submit_button;
+use function wp_die;
+use function wp_get_current_user;
+use function wp_get_referer;
+use function wp_json_encode;
+use function wp_nonce_field;
+use function wp_safe_redirect;
+use function wp_unslash;
+use function wp_verify_nonce;
+
+class LogPage {
+    public function register(): void {
+        add_action( 'admin_menu', array( $this, 'register_menu' ) );
+        add_action( 'admin_post_tcn_platform_clear_logs', array( $this, 'handle_clear_logs' ) );
+    }
+
+    public function register_menu(): void {
+        add_submenu_page(
+            'tcn-platform',
+            __( 'Activity Log', 'tcnapp-connector' ),
+            __( 'Activity Log', 'tcnapp-connector' ),
+            'manage_options',
+            'tcn-platform-logs',
+            array( $this, 'render_page' )
+        );
+    }
+
+    public function handle_clear_logs(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'You do not have permission to access this page.', 'tcnapp-connector' ) );
+        }
+
+        $nonce = isset( $_POST['tcn_platform_clear_logs_nonce'] ) ? wp_unslash( $_POST['tcn_platform_clear_logs_nonce'] ) : '';
+        if ( empty( $nonce ) || ! wp_verify_nonce( $nonce, 'tcn_platform_clear_logs' ) ) {
+            wp_die( esc_html__( 'Invalid request.', 'tcnapp-connector' ) );
+        }
+
+        $actor       = wp_get_current_user();
+        $actor_label = ( $actor && $actor->ID ) ? $actor->user_login : __( 'Unknown user', 'tcnapp-connector' );
+
+        Logger::clear();
+        Logger::log(
+            'plugin',
+            __( 'Activity log cleared', 'tcnapp-connector' ),
+            array(
+                'user' => $actor_label,
+            )
+        );
+
+        $redirect = wp_get_referer();
+        if ( ! $redirect ) {
+            $redirect = admin_url( 'admin.php?page=tcn-platform-logs' );
+        }
+
+        wp_safe_redirect( add_query_arg( 'tcn_log_cleared', '1', $redirect ) );
+        exit;
+    }
+
+    public function render_page(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'You do not have permission to access this page.', 'tcnapp-connector' ) );
+        }
+
+        $logs = Logger::get_logs();
+        ?>
+        <div class="wrap tcn-platform-logs">
+            <h1><?php esc_html_e( 'TCN Platform Activity Log', 'tcnapp-connector' ); ?></h1>
+            <p class="description">
+                <?php esc_html_e( 'Review REST API calls from the TCNApp mobile client and key plugin actions. The most recent 200 entries are stored.', 'tcnapp-connector' ); ?>
+            </p>
+
+            <?php if ( isset( $_GET['tcn_log_cleared'] ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended ?>
+                <div class="notice notice-success is-dismissible">
+                    <p><?php esc_html_e( 'Activity log cleared.', 'tcnapp-connector' ); ?></p>
+                </div>
+            <?php endif; ?>
+
+            <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="tcn-platform-log-actions">
+                <?php wp_nonce_field( 'tcn_platform_clear_logs', 'tcn_platform_clear_logs_nonce' ); ?>
+                <input type="hidden" name="action" value="tcn_platform_clear_logs" />
+                <?php submit_button( __( 'Clear Log', 'tcnapp-connector' ), 'delete', 'submit', false ); ?>
+            </form>
+
+            <table class="widefat fixed striped tcn-platform-log-table">
+                <thead>
+                    <tr>
+                        <th><?php esc_html_e( 'Time', 'tcnapp-connector' ); ?></th>
+                        <th><?php esc_html_e( 'Source', 'tcnapp-connector' ); ?></th>
+                        <th><?php esc_html_e( 'Message', 'tcnapp-connector' ); ?></th>
+                        <th><?php esc_html_e( 'Details', 'tcnapp-connector' ); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php if ( empty( $logs ) ) : ?>
+                        <tr>
+                            <td colspan="4"><?php esc_html_e( 'No activity recorded yet.', 'tcnapp-connector' ); ?></td>
+                        </tr>
+                    <?php else : ?>
+                        <?php foreach ( $logs as $entry ) : ?>
+                            <tr>
+                                <td><?php echo esc_html( $this->format_time( $entry['time'] ) ); ?></td>
+                                <td><?php echo esc_html( $this->format_source( $entry['source'] ) ); ?></td>
+                                <td><?php echo esc_html( $entry['message'] ); ?></td>
+                                <td><?php echo $this->render_details( $entry['context'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+        </div>
+        <?php
+    }
+
+    protected function format_time( $timestamp ): string {
+        if ( empty( $timestamp ) ) {
+            return '—';
+        }
+
+        return date_i18n( sprintf( '%s %s', get_option( 'date_format' ), get_option( 'time_format' ) ), (int) $timestamp );
+    }
+
+    protected function format_source( string $source ): string {
+        switch ( $source ) {
+            case 'rest':
+                return __( 'REST API', 'tcnapp-connector' );
+            case 'plugin':
+                return __( 'Plugin', 'tcnapp-connector' );
+        }
+
+        return ucfirst( $source );
+    }
+
+    protected function render_details( $details ): string {
+        if ( empty( $details ) ) {
+            return '<span class="tcn-platform-log-empty">—</span>';
+        }
+
+        if ( is_scalar( $details ) ) {
+            if ( is_bool( $details ) ) {
+                return $details ? esc_html__( 'Yes', 'tcnapp-connector' ) : esc_html__( 'No', 'tcnapp-connector' );
+            }
+
+            return esc_html( (string) $details );
+        }
+
+        if ( is_array( $details ) ) {
+            $items = array();
+            foreach ( $details as $key => $value ) {
+                $label  = is_string( $key ) ? esc_html( ucfirst( str_replace( '_', ' ', $key ) ) ) : esc_html( (string) $key );
+                $items[] = sprintf(
+                    '<li><span class="tcn-platform-log-key">%s</span>%s</li>',
+                    $label,
+                    $this->render_detail_value( $value )
+                );
+            }
+
+            return '<ul class="tcn-platform-log-list">' . implode( '', $items ) . '</ul>';
+        }
+
+        if ( $details instanceof \JsonSerializable ) {
+            return '<pre class="tcn-platform-log-pre">' . esc_html( wp_json_encode( $details, JSON_PRETTY_PRINT ) ) . '</pre>';
+        }
+
+        return esc_html( (string) $details );
+    }
+
+    protected function render_detail_value( $value ): string {
+        if ( is_array( $value ) ) {
+            if ( empty( $value ) ) {
+                return '<span class="tcn-platform-log-empty">—</span>';
+            }
+
+            $encoded = wp_json_encode( $value, JSON_PRETTY_PRINT );
+            if ( false === $encoded ) {
+                $encoded = wp_json_encode( $value );
+            }
+
+            return '<pre class="tcn-platform-log-pre">' . esc_html( (string) $encoded ) . '</pre>';
+        }
+
+        if ( is_bool( $value ) ) {
+            return sprintf( '<span class="tcn-platform-log-boolean %s">%s</span>', $value ? 'is-true' : 'is-false', esc_html( $value ? __( 'Yes', 'tcnapp-connector' ) : __( 'No', 'tcnapp-connector' ) ) );
+        }
+
+        if ( is_numeric( $value ) ) {
+            return '<span class="tcn-platform-log-number">' . esc_html( (string) $value ) . '</span>';
+        }
+
+        if ( null === $value ) {
+            return '<span class="tcn-platform-log-empty">null</span>';
+        }
+
+        return '<span class="tcn-platform-log-text">' . esc_html( (string) $value ) . '</span>';
+    }
+}

--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -58,6 +58,8 @@ class SettingsPage {
 
         Options::update_login_settings( $login );
 
+        do_action( 'tcn_platform_settings_saved', $modules, $login );
+
         add_settings_error( 'tcn_platform', 'settings_saved', __( 'Settings saved.', 'tcnapp-connector' ), 'updated' );
     }
 

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -2,10 +2,12 @@
 namespace TCN\Platform;
 
 use TCN\Platform\Admin\Assets;
+use TCN\Platform\Admin\LogPage;
 use TCN\Platform\Admin\SettingsPage;
 use TCN\Platform\Auth\PasswordLoginService;
 use TCN\Platform\Membership\MembershipModule;
 use TCN\Platform\Support\Modules;
+use TCN\Platform\Support\ActivityMonitor;
 use TCN\Platform\Support\Updater;
 
 class Plugin {
@@ -42,6 +44,7 @@ class Plugin {
 
     protected function register_services(): void {
         $this->services[] = new MembershipModule( $this->modules );
+        $this->services[] = new ActivityMonitor();
         $this->services[] = new Updater();
 
         if ( $this->modules->is_enabled( Modules::MODULE_AUTH_LOGIN ) ) {
@@ -52,6 +55,7 @@ class Plugin {
 
         if ( is_admin() ) {
             $this->services[] = new SettingsPage( $this->modules );
+            $this->services[] = new LogPage();
             $this->services[] = new Assets();
         }
     }

--- a/includes/Support/ActivityMonitor.php
+++ b/includes/Support/ActivityMonitor.php
@@ -1,0 +1,234 @@
+<?php
+namespace TCN\Platform\Support;
+
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+use function __;
+use function get_current_user_id;
+use function get_userdata;
+use function sanitize_text_field;
+
+class ActivityMonitor {
+    /**
+     * REST namespaces handled by the monitor.
+     *
+     * @var array<int, string>
+     */
+    protected $namespaces;
+
+    public function __construct( array $namespaces = array( 'gn/v1', 'tcn-mlm/v1' ) ) {
+        $this->namespaces = $namespaces;
+    }
+
+    public function register(): void {
+        add_filter( 'rest_request_after_callbacks', array( $this, 'capture_rest_activity' ), 99, 3 );
+        add_action( 'tcn_platform_activated', array( $this, 'log_plugin_activated' ) );
+        add_action( 'tcn_platform_deactivated', array( $this, 'log_plugin_deactivated' ) );
+        add_action( 'tcn_platform_settings_saved', array( $this, 'log_settings_saved' ), 10, 2 );
+    }
+
+    /**
+     * Capture REST API usage for the mobile namespaces.
+     *
+     * @param mixed             $response Response from callbacks.
+     * @param array<string,mixed> $handler  Handler information.
+     * @param WP_REST_Request   $request  Current request.
+     *
+     * @return mixed
+     */
+    public function capture_rest_activity( $response, array $handler, $request ) {
+        if ( ! $request instanceof WP_REST_Request ) {
+            return $response;
+        }
+
+        $namespace = $this->extract_namespace( $request->get_route() );
+        if ( ! $namespace || ! in_array( $namespace, $this->namespaces, true ) ) {
+            return $response;
+        }
+
+        $status = $this->resolve_status( $response );
+        $user   = $this->resolve_user();
+        $ip     = $this->get_client_ip();
+
+        $params  = $this->scrub_params( $request->get_params() );
+        $context = array(
+            'namespace' => $namespace,
+            'status'    => $status,
+            'result'    => $response instanceof WP_Error ? 'error' : 'success',
+            'user'      => $user,
+            'ip'        => $ip,
+        );
+
+        if ( ! empty( $params ) ) {
+            $context['params'] = $params;
+        }
+
+        if ( $response instanceof WP_Error ) {
+            $context['errors'] = $this->scrub_params( $response->errors );
+        }
+
+        Logger::log(
+            'rest',
+            sprintf( '%s %s', $request->get_method(), $request->get_route() ),
+            $context
+        );
+
+        return $response;
+    }
+
+    public function log_plugin_activated(): void {
+        Logger::log(
+            'plugin',
+            __( 'Plugin activated', 'tcnapp-connector' ),
+            array(
+                'version' => TCN_PLATFORM_VERSION,
+            )
+        );
+    }
+
+    public function log_plugin_deactivated(): void {
+        Logger::log(
+            'plugin',
+            __( 'Plugin deactivated', 'tcnapp-connector' ),
+            array(
+                'version' => TCN_PLATFORM_VERSION,
+            )
+        );
+    }
+
+    public function log_settings_saved( array $modules, array $login_settings ): void {
+        $enabled_modules = array();
+        foreach ( $modules as $module => $enabled ) {
+            if ( $enabled ) {
+                $enabled_modules[] = $module;
+            }
+        }
+
+        Logger::log(
+            'plugin',
+            __( 'Settings updated', 'tcnapp-connector' ),
+            array(
+                'enabled_modules'  => $enabled_modules,
+                'allowed_origin'   => isset( $login_settings['allowed_origin'] ) ? $login_settings['allowed_origin'] : '',
+                'allow_dev_http'   => ! empty( $login_settings['allow_dev_http'] ),
+                'token_lifetime'   => isset( $login_settings['token_lifetime'] ) ? (int) $login_settings['token_lifetime'] : 0,
+                'rate_limit'       => isset( $login_settings['rate_limit'] ) ? (int) $login_settings['rate_limit'] : 0,
+                'rate_limit_window'=> isset( $login_settings['rate_limit_window'] ) ? (int) $login_settings['rate_limit_window'] : 0,
+            )
+        );
+    }
+
+    protected function extract_namespace( string $route ): string {
+        $route = trim( $route, '/' );
+        if ( '' === $route ) {
+            return '';
+        }
+
+        $segments = explode( '/', $route );
+        if ( count( $segments ) < 2 ) {
+            return '';
+        }
+
+        return $segments[0] . '/' . $segments[1];
+    }
+
+    protected function resolve_status( $response ): int {
+        if ( $response instanceof WP_REST_Response ) {
+            return (int) $response->get_status();
+        }
+
+        if ( $response instanceof WP_Error ) {
+            $data = $response->get_error_data();
+            if ( is_array( $data ) && isset( $data['status'] ) ) {
+                return (int) $data['status'];
+            }
+
+            if ( is_numeric( $data ) ) {
+                return (int) $data;
+            }
+
+            return 500;
+        }
+
+        return 200;
+    }
+
+    protected function resolve_user(): string {
+        $user_id = get_current_user_id();
+        if ( ! $user_id ) {
+            return __( 'Guest', 'tcnapp-connector' );
+        }
+
+        $user = get_userdata( $user_id );
+        if ( ! $user ) {
+            return (string) $user_id;
+        }
+
+        return $user->user_login;
+    }
+
+    protected function get_client_ip(): string {
+        $ip_keys = array( 'HTTP_X_FORWARDED_FOR', 'REMOTE_ADDR' );
+        foreach ( $ip_keys as $key ) {
+            if ( empty( $_SERVER[ $key ] ) ) {
+                continue;
+            }
+
+            $raw = explode( ',', (string) $_SERVER[ $key ] );
+            $ip  = trim( $raw[0] );
+            if ( filter_var( $ip, FILTER_VALIDATE_IP ) ) {
+                return $ip;
+            }
+        }
+
+        return 'unknown';
+    }
+
+    protected function scrub_params( $params ) {
+        if ( empty( $params ) ) {
+            return array();
+        }
+
+        $keys_to_redact = array( 'password', 'pass', 'pass1', 'pass2', 'current_password', 'new_password', 'token', 'otp', 'secret' );
+
+        if ( is_array( $params ) ) {
+            $sanitized = array();
+            foreach ( $params as $key => $value ) {
+                $clean_key = is_string( $key ) ? $this->normalize_key( $key ) : $key;
+                if ( is_string( $clean_key ) && in_array( $clean_key, $keys_to_redact, true ) ) {
+                    $sanitized[ $clean_key ] = '••••';
+                    continue;
+                }
+
+                $sanitized[ $clean_key ] = $this->scrub_params( $value );
+            }
+
+            return $sanitized;
+        }
+
+        if ( is_scalar( $params ) ) {
+            if ( is_bool( $params ) ) {
+                return (bool) $params;
+            }
+
+            if ( is_numeric( $params ) ) {
+                return 0 + $params;
+            }
+
+            return sanitize_text_field( (string) $params );
+        }
+
+        if ( null === $params ) {
+            return null;
+        }
+
+        return (array) $params;
+    }
+
+    protected function normalize_key( string $key ): string {
+        $key = strtolower( $key );
+        return preg_replace( '/[^a-z0-9_\-\.]/', '_', $key );
+    }
+}

--- a/includes/Support/Logger.php
+++ b/includes/Support/Logger.php
@@ -1,0 +1,110 @@
+<?php
+namespace TCN\Platform\Support;
+
+use function current_time;
+use function delete_option;
+use function get_option;
+use function sanitize_text_field;
+use function update_option;
+
+class Logger {
+    const OPTION_KEY   = 'tcn_platform_activity_log';
+    const MAX_ENTRIES  = 200;
+
+    /**
+     * Record a new log entry.
+     */
+    public static function log( string $source, string $message, array $context = array() ): void {
+        $entry = array(
+            'time'    => self::now(),
+            'source'  => self::sanitize_key( $source ),
+            'message' => self::sanitize_text( $message ),
+            'context' => self::sanitize_context( $context ),
+        );
+
+        $logs = get_option( self::OPTION_KEY, array() );
+        if ( ! is_array( $logs ) ) {
+            $logs = array();
+        }
+
+        array_unshift( $logs, $entry );
+        if ( count( $logs ) > self::MAX_ENTRIES ) {
+            $logs = array_slice( $logs, 0, self::MAX_ENTRIES );
+        }
+
+        update_option( self::OPTION_KEY, $logs, false );
+    }
+
+    /**
+     * Retrieve all log entries.
+     */
+    public static function get_logs(): array {
+        $logs = get_option( self::OPTION_KEY, array() );
+        if ( ! is_array( $logs ) ) {
+            return array();
+        }
+
+        return $logs;
+    }
+
+    /**
+     * Remove all log entries.
+     */
+    public static function clear(): void {
+        delete_option( self::OPTION_KEY );
+    }
+
+    protected static function sanitize_context( array $context ): array {
+        $sanitized = array();
+
+        foreach ( $context as $key => $value ) {
+            $clean_key = is_string( $key ) ? self::sanitize_key( $key ) : $key;
+            $sanitized[ $clean_key ] = self::sanitize_value( $value );
+        }
+
+        return $sanitized;
+    }
+
+    protected static function sanitize_value( $value ) {
+        if ( is_array( $value ) ) {
+            $result = array();
+            foreach ( $value as $key => $item ) {
+                $clean_key         = is_string( $key ) ? self::sanitize_key( $key ) : $key;
+                $result[ $clean_key ] = self::sanitize_value( $item );
+            }
+            return $result;
+        }
+
+        if ( is_object( $value ) ) {
+            $value = (array) $value;
+            return self::sanitize_value( $value );
+        }
+
+        if ( is_bool( $value ) ) {
+            return $value;
+        }
+
+        if ( is_numeric( $value ) ) {
+            return 0 + $value;
+        }
+
+        if ( null === $value ) {
+            return null;
+        }
+
+        return self::sanitize_text( (string) $value );
+    }
+
+    protected static function sanitize_key( string $key ): string {
+        $key = strtolower( $key );
+        return preg_replace( '/[^a-z0-9_\-\.]/', '_', $key );
+    }
+
+    protected static function sanitize_text( string $text ): string {
+        return sanitize_text_field( $text );
+    }
+
+    protected static function now(): int {
+        return (int) current_time( 'timestamp', true );
+    }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -27,6 +27,11 @@ Configure modules under **TCN Platform → Modules**. The Membership & MLM modul
 * **Allowed CORS Origin** – Exact origin permitted to post to `gn/v1` endpoints. Leave blank to restrict to same-origin calls.
 * **Allow HTTP During Development** – Permits non-HTTPS requests when `WP_DEBUG` is true; use only on local environments. You can further customise HTTPS behaviour via the `gn_password_api_allow_dev_http` filter.
 
+== Activity Log ==
+* Monitor REST activity and plugin events from **TCN Platform → Activity Log** in the WordPress admin.
+* The log records calls to `gn/v1/*` and `tcn-mlm/v1/*`, automatically redacting sensitive payload fields such as passwords and tokens.
+* Plugin activation, deactivation, settings updates, and manual log clears also appear so administrators can audit configuration changes.
+
 == Mobile App Integration ==
 * TCNApp uses `/wp-json/gn/v1/*` for authentication and `/wp-json/tcn-mlm/v1/*` for membership data.
 * `/wp-json/gn/v1/login` accepts `mode=token` for cross-origin hand-offs plus optional IP / user-agent locking filters.


### PR DESCRIPTION
## Summary
- add a reusable logger and activity monitor to persist REST requests and plugin lifecycle events
- expose a new Activity Log admin submenu with styled table output and the ability to clear entries
- document the new monitoring screen and update admin styles to support the log layout

## Testing
- php -l includes/Support/Logger.php
- php -l includes/Support/ActivityMonitor.php
- php -l includes/Admin/LogPage.php
- php -l includes/Plugin.php
- php -l includes/Admin/SettingsPage.php

------
https://chatgpt.com/codex/tasks/task_e_68e0ef954b588327b07863d96b39cff8