### PR TITLE
Add success flag to token login response

### DIFF
--- a/includes/Auth/PasswordLoginService.php
+++ b/includes/Auth/PasswordLoginService.php
@@ -127,6 +127,7 @@ class PasswordLoginService {
         $token = $this->issue_login_token( $user->ID );
 
         return array(
+            'success'     => true,
             'token'       => $token['token'],
             'expires_in'  => $token['expires_in'],
             'redirect'    => add_query_arg(


### PR DESCRIPTION
## Summary
- include a success flag in the token-based login response to align with cookie mode output

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e0f5307a0483279de6ff35045a401b