### PR TITLE
Bump plugin version to 0.3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.12
+- Maintenance release to bump the plugin version for distribution.
+
 ### 0.3.11
 - Added an Activity Monitor inside the WordPress admin to review REST traffic and plugin lifecycle events at a glance.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.11
+Stable tag: 0.3.12
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -61,8 +61,11 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.12 =
+* Maintenance release to bump the plugin version for distribution.
+
 = 0.3.11 =
-* Introduce the Activity Monitor to audit REST traffic and plugin lifecycle events directly from the WordPress admin.
+* Introduced the Activity Monitor to audit REST traffic and plugin lifecycle events directly from the WordPress admin.
 
 = 0.3.10 =
 * Sync the membership summary table with WooCommerce product pricing and suppress stray legacy tiers.

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.11
+ * Version:           0.3.12
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.11' );
+define( 'TCN_PLATFORM_VERSION', '0.3.12' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- bump the plugin metadata and internal constant to version 0.3.12
- refresh the README and WordPress readme changelog entries to reflect the new release number

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0f5a060dc8327affc605bb61ac44f