### PR TITLE
Allow membership plans endpoint for guests

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.14
+- Allow unauthenticated clients to query `/wp-json/gn/v1/memberships/plans` so the mobile membership screen works for logged-out users.
+
 ### 0.3.13
 - Restore the GN `/memberships/*` REST endpoints so the mobile upgrade flow can load plans, create Stripe payment intents, and confirm upgrades.
 - Add Stripe API key fields to the settings screen and expose the publishable key in the plans payload.

--- a/includes/Membership/MembershipModule.php
+++ b/includes/Membership/MembershipModule.php
@@ -137,7 +137,7 @@ class MembershipModule {
             array(
                 'methods'             => WP_REST_Server::READABLE,
                 'callback'            => array( $this, 'rest_get_membership_plans' ),
-                'permission_callback' => array( $this, 'rest_require_login' ),
+                'permission_callback' => '__return_true',
             )
         );
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.13
+Stable tag: 0.3.14
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -61,6 +61,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.14 =
+* Allow unauthenticated clients to load membership plans via `/wp-json/gn/v1/memberships/plans` so the mobile catalogue works for logged-out shoppers.
+
 = 0.3.13 =
 * Restored the GN membership upgrade endpoints consumed by the mobile app, including Stripe intent creation and confirmation.
 * Added Stripe key inputs to the settings screen so payment intents can be created server-side.

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.13
+ * Version:           0.3.14
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.13' );
+define( 'TCN_PLATFORM_VERSION', '0.3.14' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- allow the `/wp-json/gn/v1/memberships/plans` endpoint to be accessed without authentication so the membership screen loads for guests
- bump the plugin version to 0.3.14 and update the documentation changelog entries

## Testing
- php -l includes/Membership/MembershipModule.php

------
https://chatgpt.com/codex/tasks/task_e_68e1164adbe88327af75ec93e1b0acc9