### PR TITLE
Improve activity log readability and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.15
+- Restyled the Activity Log so REST and plugin events show labeled detail rows and badges, keeping payloads intact while making them easier to read.
+
 ### 0.3.14
 - Allow unauthenticated clients to query `/wp-json/gn/v1/memberships/plans` so the mobile membership screen works for logged-out users.
 

--- a/admin/css/tcn-platform-admin.css
+++ b/admin/css/tcn-platform-admin.css
@@ -69,9 +69,53 @@
     vertical-align: top;
 }
 
+.tcn-platform-log-details {
+    margin: 0;
+}
+
+.tcn-platform-log-details.is-nested {
+    margin-top: 6px;
+}
+
+.tcn-platform-log-detail-row {
+    display: grid;
+    grid-template-columns: 160px 1fr;
+    gap: 4px 16px;
+    padding: 6px 0;
+    border-bottom: 1px solid #e2e8f0;
+}
+
+.tcn-platform-log-details.is-nested .tcn-platform-log-detail-row {
+    grid-template-columns: 140px 1fr;
+    padding: 4px 0;
+}
+
+.tcn-platform-log-detail-row:last-child {
+    border-bottom: 0;
+}
+
+.tcn-platform-log-details dt {
+    margin: 0;
+    font-weight: 600;
+    color: #1f2937;
+    text-transform: none;
+}
+
+.tcn-platform-log-details dd {
+    margin: 0;
+}
+
 .tcn-platform-log-list {
     margin: 0;
-    padding-left: 18px;
+    padding-left: 20px;
+}
+
+.tcn-platform-log-list.is-numeric {
+    list-style: decimal;
+}
+
+.tcn-platform-log-list.is-nested {
+    margin-top: 6px;
 }
 
 .tcn-platform-log-key {
@@ -97,6 +141,39 @@
 .tcn-platform-log-boolean.is-false {
     color: #b52727;
     font-weight: 600;
+}
+
+.tcn-platform-log-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+    background: #e2e8f0;
+    color: #1f2937;
+}
+
+.tcn-platform-log-badge.is-success {
+    background: #dcfce7;
+    color: #065f46;
+}
+
+.tcn-platform-log-badge.is-error {
+    background: #fee2e2;
+    color: #b91c1c;
+}
+
+.tcn-platform-log-badge.is-warning {
+    background: #fef3c7;
+    color: #b45309;
+}
+
+.tcn-platform-log-badge.is-muted {
+    background: #e0e7ff;
+    color: #4338ca;
 }
 
 .tcn-platform-log-number,

--- a/includes/Admin/LogPage.php
+++ b/includes/Admin/LogPage.php
@@ -9,6 +9,7 @@ use function add_submenu_page;
 use function admin_url;
 use function current_user_can;
 use function date_i18n;
+use function esc_attr;
 use function esc_html;
 use function esc_html__;
 use function esc_html_e;
@@ -19,6 +20,7 @@ use function wp_die;
 use function wp_get_current_user;
 use function wp_get_referer;
 use function wp_json_encode;
+use function wp_is_numeric_array;
 use function wp_nonce_field;
 use function wp_safe_redirect;
 use function wp_unslash;
@@ -147,65 +149,149 @@ class LogPage {
     }
 
     protected function render_details( $details ): string {
-        if ( empty( $details ) ) {
+        return $this->render_detail_fragment( $details );
+    }
+
+    protected function render_detail_fragment( $value, int $depth = 0, string $parent_key = '' ): string {
+        if ( null === $value ) {
             return '<span class="tcn-platform-log-empty">—</span>';
         }
 
-        if ( is_scalar( $details ) ) {
-            if ( is_bool( $details ) ) {
-                return $details ? esc_html__( 'Yes', 'tcnapp-connector' ) : esc_html__( 'No', 'tcnapp-connector' );
-            }
-
-            return esc_html( (string) $details );
-        }
-
-        if ( is_array( $details ) ) {
-            $items = array();
-            foreach ( $details as $key => $value ) {
-                $label  = is_string( $key ) ? esc_html( ucfirst( str_replace( '_', ' ', $key ) ) ) : esc_html( (string) $key );
-                $items[] = sprintf(
-                    '<li><span class="tcn-platform-log-key">%s</span>%s</li>',
-                    $label,
-                    $this->render_detail_value( $value )
-                );
-            }
-
-            return '<ul class="tcn-platform-log-list">' . implode( '', $items ) . '</ul>';
-        }
-
-        if ( $details instanceof \JsonSerializable ) {
-            return '<pre class="tcn-platform-log-pre">' . esc_html( wp_json_encode( $details, JSON_PRETTY_PRINT ) ) . '</pre>';
-        }
-
-        return esc_html( (string) $details );
-    }
-
-    protected function render_detail_value( $value ): string {
-        if ( is_array( $value ) ) {
-            if ( empty( $value ) ) {
-                return '<span class="tcn-platform-log-empty">—</span>';
-            }
-
+        if ( $value instanceof \JsonSerializable ) {
             $encoded = wp_json_encode( $value, JSON_PRETTY_PRINT );
             if ( false === $encoded ) {
                 $encoded = wp_json_encode( $value );
             }
 
+            if ( false === $encoded ) {
+                return '<span class="tcn-platform-log-empty">—</span>';
+            }
+
             return '<pre class="tcn-platform-log-pre">' . esc_html( (string) $encoded ) . '</pre>';
         }
 
+        if ( is_object( $value ) ) {
+            $value = (array) $value;
+        }
+
+        if ( is_array( $value ) ) {
+            if ( empty( $value ) ) {
+                return '<span class="tcn-platform-log-empty">—</span>';
+            }
+
+            if ( wp_is_numeric_array( $value ) ) {
+                $items = array();
+                foreach ( $value as $item ) {
+                    $items[] = '<li>' . $this->render_detail_fragment( $item, $depth + 1 ) . '</li>';
+                }
+
+                $classes = array( 'tcn-platform-log-list', 'is-numeric' );
+                if ( $depth > 0 ) {
+                    $classes[] = 'is-nested';
+                }
+
+                return sprintf( '<ol class="%s">%s</ol>', esc_attr( implode( ' ', $classes ) ), implode( '', $items ) );
+            }
+
+            $rows = array();
+            foreach ( $value as $key => $item ) {
+                $label = $this->format_detail_label( $key );
+                $rows[] = sprintf(
+                    '<div class="tcn-platform-log-detail-row"><dt>%s</dt><dd>%s</dd></div>',
+                    esc_html( $label ),
+                    $this->render_detail_fragment( $item, $depth + 1, is_string( $key ) ? strtolower( (string) $key ) : '' )
+                );
+            }
+
+            $classes = array( 'tcn-platform-log-details' );
+            if ( $depth > 0 ) {
+                $classes[] = 'is-nested';
+            }
+
+            return sprintf( '<dl class="%s">%s</dl>', esc_attr( implode( ' ', $classes ) ), implode( '', $rows ) );
+        }
+
         if ( is_bool( $value ) ) {
-            return sprintf( '<span class="tcn-platform-log-boolean %s">%s</span>', $value ? 'is-true' : 'is-false', esc_html( $value ? __( 'Yes', 'tcnapp-connector' ) : __( 'No', 'tcnapp-connector' ) ) );
+            return sprintf(
+                '<span class="tcn-platform-log-boolean %s">%s</span>',
+                $value ? 'is-true' : 'is-false',
+                esc_html( $value ? __( 'Yes', 'tcnapp-connector' ) : __( 'No', 'tcnapp-connector' ) )
+            );
         }
 
         if ( is_numeric( $value ) ) {
-            return '<span class="tcn-platform-log-number">' . esc_html( (string) $value ) . '</span>';
+            return sprintf( '<span class="tcn-platform-log-number">%s</span>', esc_html( (string) $value ) );
         }
 
-        if ( null === $value ) {
-            return '<span class="tcn-platform-log-empty">null</span>';
+        if ( is_string( $value ) ) {
+            $trimmed = trim( $value );
+            if ( '' === $trimmed ) {
+                return '<span class="tcn-platform-log-empty">—</span>';
+            }
+
+            $lower_value = strtolower( $trimmed );
+
+            if ( 'result' === $parent_key ) {
+                $class = 'tcn-platform-log-badge';
+                if ( in_array( $lower_value, array( 'success', 'ok' ), true ) ) {
+                    $class .= ' is-success';
+                } elseif ( in_array( $lower_value, array( 'error', 'fail', 'failure' ), true ) ) {
+                    $class .= ' is-error';
+                }
+
+                return sprintf( '<span class="%s">%s</span>', esc_attr( $class ), esc_html( ucfirst( $lower_value ) ) );
+            }
+
+            if ( 'log_level' === $parent_key ) {
+                $class = 'tcn-platform-log-badge';
+                if ( in_array( $lower_value, array( 'warn', 'warning' ), true ) ) {
+                    $class .= ' is-warning';
+                } elseif ( in_array( $lower_value, array( 'error', 'critical' ), true ) ) {
+                    $class .= ' is-error';
+                } elseif ( in_array( $lower_value, array( 'debug' ), true ) ) {
+                    $class .= ' is-muted';
+                } else {
+                    $class .= ' is-success';
+                }
+
+                return sprintf( '<span class="%s">%s</span>', esc_attr( $class ), esc_html( strtoupper( $trimmed ) ) );
+            }
+
+            return sprintf( '<span class="tcn-platform-log-text">%s</span>', esc_html( $trimmed ) );
         }
 
-        return '<span class="tcn-platform-log-text">' . esc_html( (string) $value ) . '</span>';
+        return esc_html( (string) $value );
+    }
+
+    protected function format_detail_label( $key ): string {
+        if ( is_int( $key ) ) {
+            /* translators: %d: Item number. */
+            return sprintf( __( 'Item %d', 'tcnapp-connector' ), $key + 1 );
+        }
+
+        $normalized = strtolower( (string) $key );
+
+        $map = array(
+            'namespace'     => __( 'Namespace', 'tcnapp-connector' ),
+            'status'        => __( 'Status Code', 'tcnapp-connector' ),
+            'result'        => __( 'Result', 'tcnapp-connector' ),
+            'user'          => __( 'User', 'tcnapp-connector' ),
+            'ip'            => __( 'IP Address', 'tcnapp-connector' ),
+            'ip_address'    => __( 'IP Address', 'tcnapp-connector' ),
+            'params'        => __( 'Parameters', 'tcnapp-connector' ),
+            'errors'        => __( 'Errors', 'tcnapp-connector' ),
+            'log_level'     => __( 'Log Level', 'tcnapp-connector' ),
+            'log_message'   => __( 'Log Message', 'tcnapp-connector' ),
+            'log_timestamp' => __( 'Log Timestamp', 'tcnapp-connector' ),
+            'log_source'    => __( 'Log Source', 'tcnapp-connector' ),
+            'log_params'    => __( 'Log Parameters', 'tcnapp-connector' ),
+            'planid'        => __( 'Plan ID', 'tcnapp-connector' ),
+        );
+
+        if ( isset( $map[ $normalized ] ) ) {
+            return $map[ $normalized ];
+        }
+
+        return ucwords( preg_replace( '/[_\-.]+/', ' ', (string) $key ) );
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.14
+Stable tag: 0.3.15
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -61,6 +61,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.15 =
+* Reformat the Activity Log details with clear labels, badges, and list styling so REST calls mirror the original payloads while remaining easy to scan.
+
 = 0.3.14 =
 * Allow unauthenticated clients to load membership plans via `/wp-json/gn/v1/memberships/plans` so the mobile catalogue works for logged-out shoppers.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.14
+ * Version:           0.3.15
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.14' );
+define( 'TCN_PLATFORM_VERSION', '0.3.15' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- rebuild the Activity Log detail renderer to produce labeled definition lists, list views, and badges while preserving the original payload data
- add admin CSS to style the new layout for nested data and status badges
- bump the plugin to version 0.3.15 and document the release in both readmes

## Testing
- php -l includes/Admin/LogPage.php

------
https://chatgpt.com/codex/tasks/task_e_68e121457f7483279f2ef47eb73a83e8