### PR TITLE
Enhance activity log UI with DataTables

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.16
+- Refresh the Activity Log UI with a responsive DataTable that adds instant search, pagination, and filtering while keeping entries easy to scan on any screen size.
+
 ### 0.3.15
 - Restyled the Activity Log so REST and plugin events show labeled detail rows and badges, keeping payloads intact while making them easier to read.
 

--- a/admin/css/tcn-platform-admin.css
+++ b/admin/css/tcn-platform-admin.css
@@ -185,3 +185,98 @@
     color: #64748b;
     font-style: italic;
 }
+
+.tcn-platform-log-table-wrapper {
+    margin-top: 1.5rem;
+}
+
+.tcn-platform-log-table.dataTable {
+    width: 100% !important;
+}
+
+.tcn-platform-log-table tbody td {
+    word-break: break-word;
+}
+
+.tcn-platform-log-controls,
+.tcn-platform-log-footer {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+    justify-content: space-between;
+    margin: 0 0 12px;
+}
+
+.tcn-platform-log-footer {
+    margin-top: 16px;
+}
+
+.dataTables_wrapper .dataTables_filter label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0;
+}
+
+.dataTables_wrapper .dataTables_filter input {
+    border-radius: 4px;
+    border: 1px solid #ccd0d4;
+    padding: 4px 10px;
+    min-width: 220px;
+    background: #fff;
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.dataTables_wrapper .dataTables_length select {
+    border-radius: 4px;
+    border: 1px solid #ccd0d4;
+    padding: 2px 6px;
+    background: #fff;
+}
+
+.dataTables_wrapper .dataTables_paginate {
+    margin: 0;
+}
+
+.dataTables_wrapper .dataTables_paginate .paginate_button {
+    border-radius: 4px !important;
+    border: 1px solid transparent !important;
+    padding: 4px 10px !important;
+    margin: 0 2px !important;
+    color: #1d2327 !important;
+}
+
+.dataTables_wrapper .dataTables_paginate .paginate_button:hover {
+    background: #f0f6fc !important;
+    border-color: #c3daf3 !important;
+}
+
+.dataTables_wrapper .dataTables_paginate .paginate_button.current,
+.dataTables_wrapper .dataTables_paginate .paginate_button.current:hover {
+    background: #2271b1 !important;
+    color: #fff !important;
+    border-color: #1c5c92 !important;
+}
+
+@media screen and (max-width: 782px) {
+    .tcn-platform-log-controls,
+    .tcn-platform-log-footer {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 16px;
+    }
+
+    .dataTables_wrapper .dataTables_filter label {
+        width: 100%;
+    }
+
+    .dataTables_wrapper .dataTables_filter input {
+        width: 100%;
+        min-width: 0;
+    }
+
+    .dataTables_wrapper .dataTables_length select {
+        width: 100%;
+    }
+}

--- a/admin/js/tcn-platform-admin.js
+++ b/admin/js/tcn-platform-admin.js
@@ -1,0 +1,40 @@
+(function ($) {
+    'use strict';
+
+    $(function () {
+        var $logTable = $('.tcn-platform-log-table');
+
+        if (!$logTable.length) {
+            return;
+        }
+
+        if (!$.fn.DataTable) {
+            return;
+        }
+
+        var localized = (window.tcnPlatformAdmin && window.tcnPlatformAdmin.logTable) ? window.tcnPlatformAdmin.logTable : {};
+        var options = {
+            pageLength: 25,
+            responsive: true,
+            order: [[0, 'desc']],
+            autoWidth: false,
+            language: localized,
+            dom: '<"tcn-platform-log-controls"lf>rt<"tcn-platform-log-footer"ip>'
+        };
+
+        if (localized.lengthMenuAll) {
+            options.lengthMenu = [
+                [10, 25, 50, 100, -1],
+                [10, 25, 50, 100, localized.lengthMenuAll]
+            ];
+        }
+
+        if (localized.searchPlaceholder) {
+            options.language = $.extend(true, {}, localized, {
+                searchPlaceholder: localized.searchPlaceholder
+            });
+        }
+
+        $logTable.DataTable(options);
+    });
+})(jQuery);

--- a/includes/Admin/Assets.php
+++ b/includes/Admin/Assets.php
@@ -1,6 +1,8 @@
 <?php
 namespace TCN\Platform\Admin;
 
+use function esc_html__;
+
 class Assets {
     public function register(): void {
         add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
@@ -18,5 +20,82 @@ class Assets {
             array(),
             TCN_PLATFORM_VERSION
         );
+
+        $is_log_screen = false !== strpos( $screen->id, 'tcn-platform-logs' );
+
+        if ( $is_log_screen ) {
+            wp_enqueue_style(
+                'tcn-platform-datatables',
+                'https://cdn.datatables.net/1.13.8/css/jquery.dataTables.min.css',
+                array(),
+                '1.13.8'
+            );
+
+            wp_enqueue_style(
+                'tcn-platform-datatables-responsive',
+                'https://cdn.datatables.net/responsive/2.5.0/css/responsive.dataTables.min.css',
+                array( 'tcn-platform-datatables' ),
+                '2.5.0'
+            );
+
+            wp_enqueue_script(
+                'tcn-platform-datatables',
+                'https://cdn.datatables.net/1.13.8/js/jquery.dataTables.min.js',
+                array( 'jquery' ),
+                '1.13.8',
+                true
+            );
+
+            wp_enqueue_script(
+                'tcn-platform-datatables-responsive',
+                'https://cdn.datatables.net/responsive/2.5.0/js/dataTables.responsive.min.js',
+                array( 'tcn-platform-datatables' ),
+                '2.5.0',
+                true
+            );
+        }
+
+        $dependencies = array( 'jquery' );
+        if ( $is_log_screen ) {
+            $dependencies[] = 'tcn-platform-datatables-responsive';
+        }
+
+        wp_enqueue_script(
+            'tcn-platform-admin',
+            TCN_PLATFORM_PLUGIN_URL . 'admin/js/tcn-platform-admin.js',
+            $dependencies,
+            TCN_PLATFORM_VERSION,
+            true
+        );
+
+        if ( $is_log_screen ) {
+            wp_localize_script(
+                'tcn-platform-admin',
+                'tcnPlatformAdmin',
+                array(
+                    'logTable' => array(
+                        'search'            => esc_html__( 'Search logs:', 'tcnapp-connector' ),
+                        'searchPlaceholder' => esc_html__( 'Search logs…', 'tcnapp-connector' ),
+                        'lengthMenu'        => esc_html__( 'Show _MENU_ entries', 'tcnapp-connector' ),
+                        'info'              => esc_html__( 'Showing _START_ to _END_ of _TOTAL_ entries', 'tcnapp-connector' ),
+                        'infoEmpty'         => esc_html__( 'Showing 0 to 0 of 0 entries', 'tcnapp-connector' ),
+                        'infoFiltered'      => esc_html__( '(filtered from _MAX_ total entries)', 'tcnapp-connector' ),
+                        'emptyTable'        => esc_html__( 'No activity recorded yet.', 'tcnapp-connector' ),
+                        'zeroRecords'       => esc_html__( 'No matching activity found.', 'tcnapp-connector' ),
+                        'paginate'          => array(
+                            'first'    => esc_html__( 'First', 'tcnapp-connector' ),
+                            'last'     => esc_html__( 'Last', 'tcnapp-connector' ),
+                            'next'     => esc_html__( 'Next', 'tcnapp-connector' ),
+                            'previous' => esc_html__( 'Previous', 'tcnapp-connector' ),
+                        ),
+                        'aria'              => array(
+                            'sortAscending'  => esc_html__( ': activate to sort column ascending', 'tcnapp-connector' ),
+                            'sortDescending' => esc_html__( ': activate to sort column descending', 'tcnapp-connector' ),
+                        ),
+                        'lengthMenuAll'     => esc_html__( 'All', 'tcnapp-connector' ),
+                    ),
+                )
+            );
+        }
     }
 }

--- a/includes/Admin/LogPage.php
+++ b/includes/Admin/LogPage.php
@@ -99,32 +99,35 @@ class LogPage {
                 <?php submit_button( __( 'Clear Log', 'tcnapp-connector' ), 'delete', 'submit', false ); ?>
             </form>
 
-            <table class="widefat fixed striped tcn-platform-log-table">
-                <thead>
-                    <tr>
-                        <th><?php esc_html_e( 'Time', 'tcnapp-connector' ); ?></th>
-                        <th><?php esc_html_e( 'Source', 'tcnapp-connector' ); ?></th>
-                        <th><?php esc_html_e( 'Message', 'tcnapp-connector' ); ?></th>
-                        <th><?php esc_html_e( 'Details', 'tcnapp-connector' ); ?></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <?php if ( empty( $logs ) ) : ?>
+            <div class="tcn-platform-log-table-wrapper">
+                <table id="tcn-platform-log-table" class="widefat fixed striped tcn-platform-log-table display nowrap" style="width:100%">
+                    <thead>
                         <tr>
-                            <td colspan="4"><?php esc_html_e( 'No activity recorded yet.', 'tcnapp-connector' ); ?></td>
+                            <th><?php esc_html_e( 'Time', 'tcnapp-connector' ); ?></th>
+                            <th><?php esc_html_e( 'Source', 'tcnapp-connector' ); ?></th>
+                            <th><?php esc_html_e( 'Message', 'tcnapp-connector' ); ?></th>
+                            <th><?php esc_html_e( 'Details', 'tcnapp-connector' ); ?></th>
                         </tr>
-                    <?php else : ?>
-                        <?php foreach ( $logs as $entry ) : ?>
+                    </thead>
+                    <tbody>
+                        <?php if ( empty( $logs ) ) : ?>
                             <tr>
-                                <td><?php echo esc_html( $this->format_time( $entry['time'] ) ); ?></td>
-                                <td><?php echo esc_html( $this->format_source( $entry['source'] ) ); ?></td>
-                                <td><?php echo esc_html( $entry['message'] ); ?></td>
-                                <td><?php echo $this->render_details( $entry['context'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
+                                <td colspan="4"><?php esc_html_e( 'No activity recorded yet.', 'tcnapp-connector' ); ?></td>
                             </tr>
-                        <?php endforeach; ?>
-                    <?php endif; ?>
-                </tbody>
-            </table>
+                        <?php else : ?>
+                            <?php foreach ( $logs as $entry ) : ?>
+                                <?php $timestamp = isset( $entry['time'] ) ? (int) $entry['time'] : 0; ?>
+                                <tr>
+                                    <td data-order="<?php echo esc_attr( $timestamp ); ?>"><?php echo esc_html( $this->format_time( $timestamp ) ); ?></td>
+                                    <td><?php echo esc_html( $this->format_source( $entry['source'] ) ); ?></td>
+                                    <td><?php echo esc_html( $entry['message'] ); ?></td>
+                                    <td><?php echo $this->render_details( $entry['context'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
+                                </tr>
+                            <?php endforeach; ?>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
         </div>
         <?php
     }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.15
+Stable tag: 0.3.16
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -61,6 +61,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.16 =
+* Upgraded the Activity Log with a responsive DataTable UI that supports instant searching, filtering, pagination, and clearer sorting of timestamped events.
+
 = 0.3.15 =
 * Reformat the Activity Log details with clear labels, badges, and list styling so REST calls mirror the original payloads while remaining easy to scan.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.15
+ * Version:           0.3.16
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.15' );
+define( 'TCN_PLATFORM_VERSION', '0.3.16' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- integrate DataTables assets on the Activity Log screen and initialize the table with a new admin script for search, filtering, pagination, and responsive behaviour
- refresh the log table markup and styling to work with DataTables while improving readability on smaller screens
- bump the plugin version to 0.3.16 and document the release in both readme files

## Testing
- php -l includes/Admin/Assets.php
- php -l includes/Admin/LogPage.php

------
https://chatgpt.com/codex/tasks/task_e_68e12369ed70832798e8ca64d8c0094b