### PR TITLE
Improve activity log table responsiveness

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.17
+- Wrap long Activity Log parameter values so the DataTable columns remain readable on narrow screens.
+
 ### 0.3.16
 - Refresh the Activity Log UI with a responsive DataTable that adds instant search, pagination, and filtering while keeping entries easy to scan on any screen size.
 

--- a/admin/css/tcn-platform-admin.css
+++ b/admin/css/tcn-platform-admin.css
@@ -67,6 +67,13 @@
 .tcn-platform-log-table td,
 .tcn-platform-log-table th {
     vertical-align: top;
+    word-break: break-word;
+    overflow-wrap: anywhere;
+}
+
+.tcn-platform-log-table.nowrap td,
+.tcn-platform-log-table.nowrap th {
+    white-space: normal !important;
 }
 
 .tcn-platform-log-details {
@@ -79,14 +86,14 @@
 
 .tcn-platform-log-detail-row {
     display: grid;
-    grid-template-columns: 160px 1fr;
+    grid-template-columns: minmax(140px, 200px) minmax(0, 1fr);
     gap: 4px 16px;
     padding: 6px 0;
     border-bottom: 1px solid #e2e8f0;
 }
 
 .tcn-platform-log-details.is-nested .tcn-platform-log-detail-row {
-    grid-template-columns: 140px 1fr;
+    grid-template-columns: minmax(120px, 180px) minmax(0, 1fr);
     padding: 4px 0;
 }
 
@@ -188,14 +195,31 @@
 
 .tcn-platform-log-table-wrapper {
     margin-top: 1.5rem;
+    overflow-x: auto;
 }
 
 .tcn-platform-log-table.dataTable {
     width: 100% !important;
 }
 
-.tcn-platform-log-table tbody td {
-    word-break: break-word;
+.tcn-platform-log-table thead th.tcn-platform-log-col-time,
+.tcn-platform-log-table tbody td.tcn-platform-log-col-time {
+    width: 140px;
+}
+
+.tcn-platform-log-table thead th.tcn-platform-log-col-source,
+.tcn-platform-log-table tbody td.tcn-platform-log-col-source {
+    width: 130px;
+}
+
+.tcn-platform-log-table thead th.tcn-platform-log-col-message,
+.tcn-platform-log-table tbody td.tcn-platform-log-col-message {
+    width: 240px;
+}
+
+.tcn-platform-log-table thead th.tcn-platform-log-col-details,
+.tcn-platform-log-table tbody td.tcn-platform-log-col-details {
+    min-width: 260px;
 }
 
 .tcn-platform-log-controls,

--- a/admin/js/tcn-platform-admin.js
+++ b/admin/js/tcn-platform-admin.js
@@ -19,7 +19,13 @@
             order: [[0, 'desc']],
             autoWidth: false,
             language: localized,
-            dom: '<"tcn-platform-log-controls"lf>rt<"tcn-platform-log-footer"ip>'
+            dom: '<"tcn-platform-log-controls"lf>rt<"tcn-platform-log-footer"ip>',
+            columnDefs: [
+                { targets: 0, className: 'tcn-platform-log-col-time', width: '14%', responsivePriority: 1 },
+                { targets: 1, className: 'tcn-platform-log-col-source', width: '12%', responsivePriority: 4 },
+                { targets: 2, className: 'tcn-platform-log-col-message', width: '26%', responsivePriority: 2 },
+                { targets: 3, className: 'tcn-platform-log-col-details', responsivePriority: 3 }
+            ]
         };
 
         if (localized.lengthMenuAll) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.16
+Stable tag: 0.3.17
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -61,6 +61,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.17 =
+* Fix: Ensure long log parameters wrap within the Activity Log DataTable so columns remain readable on smaller screens.
+
 = 0.3.16 =
 * Upgraded the Activity Log with a responsive DataTable UI that supports instant searching, filtering, pagination, and clearer sorting of timestamped events.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.16
+ * Version:           0.3.17
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.16' );
+define( 'TCN_PLATFORM_VERSION', '0.3.17' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- wrap long Activity Log values and enforce column widths so the DataTable stays readable on narrow screens
- tweak detail layout grids to prevent overflow and allow horizontal scrolling as a fallback
- bump the plugin version to 0.3.17 and document the change in both readme files

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e125aec6e4832786aa17eaa30075b0