### PR TITLE
Bump plugin version to 0.3.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.18
+- Add a WooCommerce order creation endpoint to the REST service so external systems can register purchases directly from the API.
+
 ### 0.3.17
 - Wrap long Activity Log parameter values so the DataTable columns remain readable on narrow screens.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.17
+Stable tag: 0.3.18
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -61,6 +61,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.18 =
+* Feature: Add a WooCommerce order creation endpoint to the REST service so external clients can register purchases programmatically.
+
 = 0.3.17 =
 * Fix: Ensure long log parameters wrap within the Activity Log DataTable so columns remain readable on smaller screens.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.17
+ * Version:           0.3.18
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.17' );
+define( 'TCN_PLATFORM_VERSION', '0.3.18' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- bump the plugin header and internal version constant to 0.3.18
- update both readme files with the new stable tag and release notes for the WooCommerce order creation endpoint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e141cf13e48327be9ff854dd2cfcbc