### PR TITLE
Add WooCommerce API key authentication to gn endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.19
+- Allow WooCommerce REST API consumer keys to authenticate the `gn/v1` customer and order endpoints for secure headless integrations.
+
 ### 0.3.18
 - Add a WooCommerce order creation endpoint to the REST service so external systems can register purchases directly from the API.
 

--- a/includes/Rest/WooCommerceEndpoints.php
+++ b/includes/Rest/WooCommerceEndpoints.php
@@ -116,6 +116,20 @@ class WooCommerceEndpoints {
             return true;
         }
 
+        $authenticated_user = $this->authenticate_with_consumer_keys( $request );
+
+        if ( $authenticated_user > 0 ) {
+            if ( user_can( $authenticated_user, 'manage_woocommerce' ) ) {
+                return true;
+            }
+
+            return new WP_Error(
+                'tcn_rest_forbidden',
+                __( 'The API key provided does not have permission to manage WooCommerce customers.', 'tcnapp-connector' ),
+                array( 'status' => rest_authorization_required_code() )
+            );
+        }
+
         if ( is_user_logged_in() ) {
             return new WP_Error(
                 'tcn_rest_forbidden',
@@ -129,6 +143,135 @@ class WooCommerceEndpoints {
             __( 'Authentication is required to access this resource.', 'tcnapp-connector' ),
             array( 'status' => rest_authorization_required_code() )
         );
+    }
+
+    /**
+     * Attempt to authenticate the request using WooCommerce REST API keys.
+     */
+    protected function authenticate_with_consumer_keys( WP_REST_Request $request ): int {
+        if ( ! function_exists( 'wc_api_hash' ) ) {
+            return 0;
+        }
+
+        global $wpdb;
+
+        if ( ! $wpdb instanceof \wpdb ) {
+            return 0;
+        }
+
+        $credentials = $this->extract_consumer_credentials( $request );
+
+        if ( empty( $credentials['key'] ) || empty( $credentials['secret'] ) ) {
+            return 0;
+        }
+
+        $table = $wpdb->prefix . 'woocommerce_api_keys';
+        $hash  = wc_api_hash( $credentials['key'] );
+
+        $key_data = $wpdb->get_row(
+            $wpdb->prepare(
+                "SELECT key_id, user_id, permissions, consumer_secret FROM {$table} WHERE consumer_key = %s",
+                $hash
+            )
+        );
+
+        if ( empty( $key_data ) ) {
+            return 0;
+        }
+
+        $permissions = isset( $key_data->permissions ) ? strtolower( (string) $key_data->permissions ) : '';
+
+        if ( ! in_array( $permissions, array( 'write', 'read_write' ), true ) ) {
+            return 0;
+        }
+
+        $secret = isset( $key_data->consumer_secret ) ? (string) $key_data->consumer_secret : '';
+
+        if ( ! $this->safe_hash_equals( $secret, $credentials['secret'] ) ) {
+            return 0;
+        }
+
+        $user_id = isset( $key_data->user_id ) ? (int) $key_data->user_id : 0;
+
+        if ( $user_id <= 0 || ! get_user_by( 'id', $user_id ) ) {
+            return 0;
+        }
+
+        wp_set_current_user( $user_id );
+
+        if ( isset( $key_data->key_id ) ) {
+            $wpdb->update(
+                $table,
+                array( 'last_access' => current_time( 'mysql', true ) ),
+                array( 'key_id' => (int) $key_data->key_id ),
+                array( '%s' ),
+                array( '%d' )
+            );
+        }
+
+        return $user_id;
+    }
+
+    /**
+     * Extract consumer key credentials from a REST request.
+     */
+    protected function extract_consumer_credentials( WP_REST_Request $request ): array {
+        $key    = '';
+        $secret = '';
+
+        $header = $request->get_header( 'authorization' );
+
+        if ( is_string( $header ) && stripos( $header, 'basic ' ) === 0 ) {
+            $decoded = base64_decode( substr( $header, 6 ), true );
+
+            if ( false !== $decoded ) {
+                $parts  = explode( ':', $decoded, 2 );
+                $key    = isset( $parts[0] ) ? trim( $parts[0] ) : '';
+                $secret = isset( $parts[1] ) ? trim( $parts[1] ) : '';
+            }
+        }
+
+        if ( '' === $key && '' === $secret ) {
+            $param_key    = $request->get_param( 'consumer_key' );
+            $param_secret = $request->get_param( 'consumer_secret' );
+
+            if ( is_string( $param_key ) ) {
+                $key = trim( wp_unslash( $param_key ) );
+            }
+
+            if ( is_string( $param_secret ) ) {
+                $secret = trim( wp_unslash( $param_secret ) );
+            }
+        }
+
+        return array(
+            'key'    => $key,
+            'secret' => $secret,
+        );
+    }
+
+    /**
+     * Compare two strings in a time-safe manner where possible.
+     */
+    protected function safe_hash_equals( string $expected, string $actual ): bool {
+        if ( function_exists( 'hash_equals' ) ) {
+            return hash_equals( $expected, $actual );
+        }
+
+        $expected_length = strlen( $expected );
+        $actual_length   = strlen( $actual );
+
+        if ( $expected_length !== $actual_length ) {
+            return false;
+        }
+
+        $result = 0;
+
+        for ( $i = 0; $i < $expected_length; $i++ ) {
+            $result |= ord( $expected[ $i ] ) ^ ord( $actual[ $i ] );
+        }
+
+        return 0 === $result;
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.18
+Stable tag: 0.3.19
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -61,6 +61,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.19 =
+* Enhancement: Allow WooCommerce REST API consumer keys to authenticate `gn/v1` customer and order endpoints for trusted integrators.
+
 = 0.3.18 =
 * Feature: Add a WooCommerce order creation endpoint to the REST service so external clients can register purchases programmatically.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.18
+ * Version:           0.3.19
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.18' );
+define( 'TCN_PLATFORM_VERSION', '0.3.19' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- allow WooCommerce REST API consumer keys to authenticate the gn/v1 customer and order endpoints
- set the current user when authenticating and update API key access metadata while honouring WooCommerce permissions
- bump the plugin version to 0.3.19 and update the readme changelog

## Testing
- php -l includes/Rest/WooCommerceEndpoints.php

------
https://chatgpt.com/codex/tasks/task_e_68e145c2020c8327933d32b7bbdc2251