### PR TITLE
Add admin API tester interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.20
+- Added an API Tester admin screen that mirrors Postman inside WordPress, letting you compose requests, send them to plugin endpoints, and inspect the raw responses.
+- Documented starter examples for authentication, registration, membership plans, and WooCommerce lookups so teams can quickly verify their integrations.
+
 ### 0.3.19
 - Allow WooCommerce REST API consumer keys to authenticate the `gn/v1` customer and order endpoints for secure headless integrations.
 

--- a/admin/css/tcn-platform-admin.css
+++ b/admin/css/tcn-platform-admin.css
@@ -198,6 +198,224 @@
     overflow-x: auto;
 }
 
+.tcn-platform-api-tester {
+    max-width: 960px;
+}
+
+.tcn-platform-api-tester h1 {
+    margin-bottom: 1rem;
+}
+
+.tcn-platform-api-form {
+    margin-top: 1.5rem;
+    margin-bottom: 2rem;
+    background: #fff;
+    border: 1px solid #ccd0d4;
+    border-radius: 8px;
+    padding: 24px;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.tcn-platform-api-grid {
+    display: grid;
+    grid-template-columns: minmax(120px, 160px) minmax(0, 1fr);
+    gap: 16px;
+    margin-bottom: 20px;
+}
+
+.tcn-platform-api-field {
+    margin-bottom: 20px;
+}
+
+.tcn-platform-api-field.is-wide {
+    grid-column: span 2;
+}
+
+.tcn-platform-api-label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 6px;
+}
+
+.tcn-platform-api-form select,
+.tcn-platform-api-form input[type="text"],
+.tcn-platform-api-form textarea {
+    width: 100%;
+}
+
+.tcn-platform-api-form textarea {
+    font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
+    font-size: 13px;
+}
+
+.tcn-platform-api-response {
+    background: #fff;
+    border: 1px solid #ccd0d4;
+    border-radius: 8px;
+    padding: 24px;
+    margin-bottom: 2rem;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.tcn-platform-api-meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 12px 24px;
+    margin-bottom: 1.5rem;
+}
+
+.tcn-platform-api-meta-label {
+    display: block;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #64748b;
+    margin-bottom: 4px;
+}
+
+.tcn-platform-api-meta-value {
+    font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
+    word-break: break-word;
+}
+
+.tcn-platform-api-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 600;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: #f1f5f9;
+    color: #0f172a;
+}
+
+.tcn-platform-api-status small {
+    font-size: 12px;
+    font-weight: 500;
+}
+
+.tcn-platform-api-details {
+    margin-top: 1rem;
+}
+
+.tcn-platform-api-details summary {
+    cursor: pointer;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+}
+
+.tcn-platform-api-details pre {
+    background: #f6f7f7;
+    border-radius: 6px;
+    padding: 12px;
+    margin: 0;
+    overflow-x: auto;
+}
+
+.tcn-platform-api-details-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 16px;
+}
+
+.tcn-platform-api-examples {
+    background: #fff;
+    border: 1px solid #ccd0d4;
+    border-radius: 8px;
+    padding: 24px;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.tcn-platform-api-examples-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 20px;
+    margin-top: 1.5rem;
+}
+
+.tcn-platform-api-example {
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    padding: 16px;
+    background: #f8fafc;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.tcn-platform-api-example-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+}
+
+.tcn-platform-api-method {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2px 10px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    background: #e2e8f0;
+    color: #0f172a;
+}
+
+.tcn-platform-api-method-post {
+    background: #dbeafe;
+    color: #1d4ed8;
+}
+
+.tcn-platform-api-method-get {
+    background: #dcfce7;
+    color: #047857;
+}
+
+.tcn-platform-api-method-delete {
+    background: #fee2e2;
+    color: #b91c1c;
+}
+
+.tcn-platform-api-method-put,
+.tcn-platform-api-method-patch {
+    background: #ede9fe;
+    color: #6d28d9;
+}
+
+.tcn-platform-api-path {
+    font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
+    font-size: 12px;
+    background: #fff;
+    border-radius: 4px;
+    padding: 2px 6px;
+    color: #0f172a;
+}
+
+.tcn-platform-api-example details pre {
+    max-height: 220px;
+}
+
+.tcn-platform-api-example .description {
+    color: #475569;
+    margin: 0;
+}
+
+.tcn-platform-api-example button.button {
+    align-self: flex-start;
+}
+
+@media (max-width: 782px) {
+    .tcn-platform-api-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .tcn-platform-api-field.is-wide {
+        grid-column: auto;
+    }
+}
+
 .tcn-platform-log-table.dataTable {
     width: 100% !important;
 }

--- a/admin/js/tcn-platform-admin.js
+++ b/admin/js/tcn-platform-admin.js
@@ -4,43 +4,78 @@
     $(function () {
         var $logTable = $('.tcn-platform-log-table');
 
-        if (!$logTable.length) {
-            return;
+        if ($logTable.length && $.fn.DataTable) {
+            var localized = (window.tcnPlatformAdmin && window.tcnPlatformAdmin.logTable) ? window.tcnPlatformAdmin.logTable : {};
+            var options = {
+                pageLength: 25,
+                responsive: true,
+                order: [[0, 'desc']],
+                autoWidth: false,
+                language: localized,
+                dom: '<"tcn-platform-log-controls"lf>rt<"tcn-platform-log-footer"ip>',
+                columnDefs: [
+                    { targets: 0, className: 'tcn-platform-log-col-time', width: '14%', responsivePriority: 1 },
+                    { targets: 1, className: 'tcn-platform-log-col-source', width: '12%', responsivePriority: 4 },
+                    { targets: 2, className: 'tcn-platform-log-col-message', width: '26%', responsivePriority: 2 },
+                    { targets: 3, className: 'tcn-platform-log-col-details', responsivePriority: 3 }
+                ]
+            };
+
+            if (localized.lengthMenuAll) {
+                options.lengthMenu = [
+                    [10, 25, 50, 100, -1],
+                    [10, 25, 50, 100, localized.lengthMenuAll]
+                ];
+            }
+
+            if (localized.searchPlaceholder) {
+                options.language = $.extend(true, {}, localized, {
+                    searchPlaceholder: localized.searchPlaceholder
+                });
+            }
+
+            $logTable.DataTable(options);
         }
 
-        if (!$.fn.DataTable) {
-            return;
-        }
+        var $apiTester = $('.tcn-platform-api-tester');
+        if ($apiTester.length) {
+            var $form = $apiTester.find('.tcn-platform-api-form');
 
-        var localized = (window.tcnPlatformAdmin && window.tcnPlatformAdmin.logTable) ? window.tcnPlatformAdmin.logTable : {};
-        var options = {
-            pageLength: 25,
-            responsive: true,
-            order: [[0, 'desc']],
-            autoWidth: false,
-            language: localized,
-            dom: '<"tcn-platform-log-controls"lf>rt<"tcn-platform-log-footer"ip>',
-            columnDefs: [
-                { targets: 0, className: 'tcn-platform-log-col-time', width: '14%', responsivePriority: 1 },
-                { targets: 1, className: 'tcn-platform-log-col-source', width: '12%', responsivePriority: 4 },
-                { targets: 2, className: 'tcn-platform-log-col-message', width: '26%', responsivePriority: 2 },
-                { targets: 3, className: 'tcn-platform-log-col-details', responsivePriority: 3 }
-            ]
-        };
+            $apiTester.on('click', '.tcn-platform-api-example-fill', function (event) {
+                event.preventDefault();
 
-        if (localized.lengthMenuAll) {
-            options.lengthMenu = [
-                [10, 25, 50, 100, -1],
-                [10, 25, 50, 100, localized.lengthMenuAll]
-            ];
-        }
+                if (!$form.length) {
+                    return;
+                }
 
-        if (localized.searchPlaceholder) {
-            options.language = $.extend(true, {}, localized, {
-                searchPlaceholder: localized.searchPlaceholder
+                var $example = $(this).closest('.tcn-platform-api-example');
+                if (!$example.length) {
+                    return;
+                }
+
+                var method = ($example.attr('data-method') || 'GET').toString().toUpperCase();
+                var url = $example.attr('data-url') || '';
+                var headers = $example.attr('data-headers') || '';
+                var body = $example.attr('data-body') || '';
+
+                $form.find('#request_method').val(method);
+                $form.find('#request_url').val(url);
+                $form.find('#request_headers').val(headers);
+                $form.find('#request_body').val(body);
+            });
+
+            $apiTester.on('click', '.tcn-platform-api-reset', function (event) {
+                event.preventDefault();
+
+                if (!$form.length) {
+                    return;
+                }
+
+                $form.find('#request_method').val('GET');
+                $form.find('#request_url').val('');
+                $form.find('#request_headers').val('');
+                $form.find('#request_body').val('');
             });
         }
-
-        $logTable.DataTable(options);
     });
 })(jQuery);

--- a/includes/Admin/ApiTesterPage.php
+++ b/includes/Admin/ApiTesterPage.php
@@ -1,0 +1,481 @@
+<?php
+namespace TCN\Platform\Admin;
+
+use WP_Error;
+use function __;
+use function add_action;
+use function add_submenu_page;
+use function check_admin_referer;
+use function current_user_can;
+use function esc_attr;
+use function esc_html;
+use function esc_html__;
+use function esc_html_e;
+use function esc_textarea;
+use function esc_url_raw;
+use function home_url;
+use function is_array;
+use function is_scalar;
+use function is_wp_error;
+use function sanitize_text_field;
+use function selected;
+use function wp_die;
+use function wp_json_encode;
+use function wp_nonce_field;
+use function wp_remote_request;
+use function wp_remote_retrieve_body;
+use function wp_remote_retrieve_headers;
+use function wp_remote_retrieve_response_code;
+use function wp_remote_retrieve_response_message;
+use function wp_parse_url;
+use function wp_unslash;
+
+class ApiTesterPage {
+    public function register(): void {
+        add_action( 'admin_menu', array( $this, 'register_menu' ) );
+    }
+
+    public function register_menu(): void {
+        add_submenu_page(
+            'tcn-platform',
+            __( 'API Tester', 'tcnapp-connector' ),
+            __( 'API Tester', 'tcnapp-connector' ),
+            'manage_options',
+            'tcn-platform-api-tester',
+            array( $this, 'render_page' )
+        );
+    }
+
+    public function render_page(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'You do not have permission to access this page.', 'tcnapp-connector' ) );
+        }
+
+        $method        = 'GET';
+        $endpoint      = '';
+        $headers_input = '';
+        $body_input    = '';
+        $errors        = array();
+        $result        = null;
+        $response      = null;
+        $request_url   = '';
+        $request_args  = array();
+
+        if ( 'POST' === $_SERVER['REQUEST_METHOD'] && isset( $_POST['tcn_platform_api_tester_nonce'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            check_admin_referer( 'tcn_platform_api_tester', 'tcn_platform_api_tester_nonce' );
+
+            $method        = isset( $_POST['request_method'] ) ? strtoupper( sanitize_text_field( wp_unslash( $_POST['request_method'] ) ) ) : 'GET';
+            $endpoint      = isset( $_POST['request_url'] ) ? trim( wp_unslash( $_POST['request_url'] ) ) : '';
+            $headers_input = isset( $_POST['request_headers'] ) ? trim( wp_unslash( $_POST['request_headers'] ) ) : '';
+            $body_input    = isset( $_POST['request_body'] ) ? (string) wp_unslash( $_POST['request_body'] ) : '';
+
+            if ( '' === $method ) {
+                $method = 'GET';
+            }
+
+            $allowed_methods = array( 'GET', 'POST', 'PUT', 'PATCH', 'DELETE' );
+            if ( ! in_array( $method, $allowed_methods, true ) ) {
+                $method = 'GET';
+            }
+
+            $request_url = $this->prepare_url( $endpoint );
+            if ( '' === $request_url ) {
+                $errors[] = esc_html__( 'Please provide a valid endpoint URL.', 'tcnapp-connector' );
+            }
+
+            $headers = array();
+            if ( '' !== $headers_input ) {
+                $decoded_headers = json_decode( $headers_input, true );
+                if ( null === $decoded_headers || ! is_array( $decoded_headers ) ) {
+                    $errors[] = esc_html__( 'Headers must be provided as a valid JSON object.', 'tcnapp-connector' );
+                } else {
+                    foreach ( $decoded_headers as $key => $value ) {
+                        if ( '' === $key ) {
+                            continue;
+                        }
+
+                        if ( is_array( $value ) || is_object( $value ) ) {
+                            $value = wp_json_encode( $value );
+                        }
+
+                        if ( ! is_scalar( $value ) ) {
+                            continue;
+                        }
+
+                        $headers[ $key ] = (string) $value;
+                    }
+                }
+            }
+
+            if ( empty( $errors ) ) {
+                $request_args = array(
+                    'method'      => $method,
+                    'headers'     => $headers,
+                    'timeout'     => 20,
+                    'redirection' => 2,
+                );
+
+                if ( '' !== $body_input ) {
+                    $request_args['body'] = $body_input;
+                }
+
+                $result = wp_remote_request( $request_url, $request_args );
+
+                if ( is_wp_error( $result ) ) {
+                    $response = $result;
+                } else {
+                    $response = array(
+                        'code'    => wp_remote_retrieve_response_code( $result ),
+                        'message' => wp_remote_retrieve_response_message( $result ),
+                        'headers' => $this->normalize_headers( wp_remote_retrieve_headers( $result ) ),
+                        'body'    => wp_remote_retrieve_body( $result ),
+                    );
+                }
+            }
+        }
+
+        $examples = $this->get_examples();
+
+        ?>
+        <div class="wrap tcn-platform-api-tester">
+            <h1><?php esc_html_e( 'TCN Platform API Tester', 'tcnapp-connector' ); ?></h1>
+            <p class="description">
+                <?php esc_html_e( 'Send requests to the plugin\'s REST endpoints without leaving the WordPress dashboard. Use the form below to craft a request, then review the response details.', 'tcnapp-connector' ); ?>
+            </p>
+
+            <?php if ( ! empty( $errors ) ) : ?>
+                <div class="notice notice-error">
+                    <ul>
+                        <?php foreach ( $errors as $error ) : ?>
+                            <li><?php echo esc_html( $error ); ?></li>
+                        <?php endforeach; ?>
+                    </ul>
+                </div>
+            <?php endif; ?>
+
+            <form method="post" class="tcn-platform-api-form">
+                <?php wp_nonce_field( 'tcn_platform_api_tester', 'tcn_platform_api_tester_nonce' ); ?>
+
+                <div class="tcn-platform-api-grid">
+                    <div class="tcn-platform-api-field">
+                        <label for="request_method" class="tcn-platform-api-label"><?php esc_html_e( 'HTTP Method', 'tcnapp-connector' ); ?></label>
+                        <select id="request_method" name="request_method">
+                            <?php foreach ( array( 'GET', 'POST', 'PUT', 'PATCH', 'DELETE' ) as $option_method ) : ?>
+                                <option value="<?php echo esc_attr( $option_method ); ?>" <?php selected( $method, $option_method ); ?>><?php echo esc_html( $option_method ); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                    <div class="tcn-platform-api-field is-wide">
+                        <label for="request_url" class="tcn-platform-api-label"><?php esc_html_e( 'Endpoint URL', 'tcnapp-connector' ); ?></label>
+                        <input type="text" id="request_url" name="request_url" class="regular-text" value="<?php echo esc_attr( $endpoint ); ?>" placeholder="<?php echo esc_attr( home_url( '/wp-json/gn/v1/login' ) ); ?>" />
+                        <p class="description"><?php esc_html_e( 'Enter a full URL or a relative path such as /wp-json/gn/v1/login.', 'tcnapp-connector' ); ?></p>
+                    </div>
+                </div>
+
+                <div class="tcn-platform-api-field">
+                    <label for="request_headers" class="tcn-platform-api-label"><?php esc_html_e( 'Headers (JSON object)', 'tcnapp-connector' ); ?></label>
+                    <textarea id="request_headers" name="request_headers" rows="4" placeholder="{&#10;  &quot;Content-Type&quot;: &quot;application/json&quot; &#10;}"><?php echo esc_textarea( $headers_input ); ?></textarea>
+                    <p class="description"><?php esc_html_e( 'Use JSON format to provide any headers (for example, authentication or content-type). Leave blank if none are required.', 'tcnapp-connector' ); ?></p>
+                </div>
+
+                <div class="tcn-platform-api-field">
+                    <label for="request_body" class="tcn-platform-api-label"><?php esc_html_e( 'Request Body', 'tcnapp-connector' ); ?></label>
+                    <textarea id="request_body" name="request_body" rows="8" placeholder="{&#10;  &quot;username&quot;: &quot;demo@example.com&quot;,&#10;  &quot;password&quot;: &quot;secret&quot;&#10;}"><?php echo esc_textarea( $body_input ); ?></textarea>
+                    <p class="description"><?php esc_html_e( 'Provide the raw request payload. JSON is common for these endpoints, but you can use any format required by the route.', 'tcnapp-connector' ); ?></p>
+                </div>
+
+                <p>
+                    <button type="submit" class="button button-primary"><?php esc_html_e( 'Send Request', 'tcnapp-connector' ); ?></button>
+                    <button type="button" class="button tcn-platform-api-reset"><?php esc_html_e( 'Clear', 'tcnapp-connector' ); ?></button>
+                </p>
+            </form>
+
+            <?php if ( null !== $response && empty( $errors ) ) : ?>
+                <div class="tcn-platform-api-response">
+                    <h2><?php esc_html_e( 'Response', 'tcnapp-connector' ); ?></h2>
+                    <?php if ( $response instanceof WP_Error ) : ?>
+                        <div class="notice notice-error">
+                            <p><strong><?php esc_html_e( 'Request failed:', 'tcnapp-connector' ); ?></strong> <?php echo esc_html( $response->get_error_message() ); ?></p>
+                            <?php $error_data = $response->get_error_data(); ?>
+                            <?php if ( ! empty( $error_data ) && is_scalar( $error_data ) ) : ?>
+                                <pre><?php echo esc_html( (string) $error_data ); ?></pre>
+                            <?php endif; ?>
+                        </div>
+                    <?php else : ?>
+                        <div class="tcn-platform-api-meta">
+                            <div>
+                                <span class="tcn-platform-api-meta-label"><?php esc_html_e( 'Endpoint', 'tcnapp-connector' ); ?></span>
+                                <span class="tcn-platform-api-meta-value"><?php echo esc_html( $method ); ?> <?php echo esc_html( $request_url ); ?></span>
+                            </div>
+                            <div>
+                                <span class="tcn-platform-api-meta-label"><?php esc_html_e( 'Status', 'tcnapp-connector' ); ?></span>
+                                <span class="tcn-platform-api-status code-<?php echo esc_attr( $response['code'] ); ?>">
+                                    <?php echo esc_html( $response['code'] ); ?>
+                                    <?php if ( ! empty( $response['message'] ) ) : ?>
+                                        <small><?php echo esc_html( $response['message'] ); ?></small>
+                                    <?php endif; ?>
+                                </span>
+                            </div>
+                        </div>
+
+                        <?php if ( ! empty( $request_args ) ) : ?>
+                            <details class="tcn-platform-api-details">
+                                <summary><?php esc_html_e( 'View request details', 'tcnapp-connector' ); ?></summary>
+                                <div class="tcn-platform-api-details-grid">
+                                    <div>
+                                        <h3><?php esc_html_e( 'Headers', 'tcnapp-connector' ); ?></h3>
+                                        <?php if ( empty( $request_args['headers'] ) ) : ?>
+                                            <p><?php esc_html_e( 'No headers sent.', 'tcnapp-connector' ); ?></p>
+                                        <?php else : ?>
+                                            <pre><?php echo esc_html( wp_json_encode( $request_args['headers'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ?: '' ); ?></pre>
+                                        <?php endif; ?>
+                                    </div>
+                                    <div>
+                                        <h3><?php esc_html_e( 'Body', 'tcnapp-connector' ); ?></h3>
+                                        <?php if ( empty( $request_args['body'] ) ) : ?>
+                                            <p><?php esc_html_e( 'No body sent.', 'tcnapp-connector' ); ?></p>
+                                        <?php else : ?>
+                                            <pre><?php echo esc_html( $this->format_body_for_display( (string) $request_args['body'] ) ); ?></pre>
+                                        <?php endif; ?>
+                                    </div>
+                                </div>
+                            </details>
+                        <?php endif; ?>
+
+                        <details class="tcn-platform-api-details" open>
+                            <summary><?php esc_html_e( 'View response headers', 'tcnapp-connector' ); ?></summary>
+                            <?php if ( empty( $response['headers'] ) ) : ?>
+                                <p><?php esc_html_e( 'No response headers returned.', 'tcnapp-connector' ); ?></p>
+                            <?php else : ?>
+                                <pre><?php echo esc_html( wp_json_encode( $response['headers'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ?: '' ); ?></pre>
+                            <?php endif; ?>
+                        </details>
+
+                        <details class="tcn-platform-api-details" open>
+                            <summary><?php esc_html_e( 'View response body', 'tcnapp-connector' ); ?></summary>
+                            <?php if ( '' === $response['body'] ) : ?>
+                                <p><?php esc_html_e( 'The response body is empty.', 'tcnapp-connector' ); ?></p>
+                            <?php else : ?>
+                                <pre><?php echo esc_html( $this->format_body_for_display( $response['body'] ) ); ?></pre>
+                            <?php endif; ?>
+                        </details>
+                    <?php endif; ?>
+                </div>
+            <?php endif; ?>
+
+            <div class="tcn-platform-api-examples">
+                <h2><?php esc_html_e( 'Example requests', 'tcnapp-connector' ); ?></h2>
+                <p class="description"><?php esc_html_e( 'Use these ready-made examples to explore key endpoints. Click “Load in tester” to populate the form above.', 'tcnapp-connector' ); ?></p>
+                <div class="tcn-platform-api-examples-grid">
+                    <?php foreach ( $examples as $example ) : ?>
+                        <div class="tcn-platform-api-example" data-url="<?php echo esc_attr( $example['url'] ); ?>" data-method="<?php echo esc_attr( $example['method'] ); ?>" data-headers="<?php echo esc_attr( $example['headers'] ); ?>" data-body="<?php echo esc_attr( $example['body'] ); ?>">
+                            <div class="tcn-platform-api-example-header">
+                                <span class="tcn-platform-api-method tcn-platform-api-method-<?php echo esc_attr( strtolower( $example['method'] ) ); ?>"><?php echo esc_html( $example['method'] ); ?></span>
+                                <code class="tcn-platform-api-path"><?php echo esc_html( $this->abbreviate_url( $example['url'] ) ); ?></code>
+                            </div>
+                            <p><?php echo esc_html( $example['description'] ); ?></p>
+                            <?php if ( ! empty( $example['note'] ) ) : ?>
+                                <p class="description"><?php echo esc_html( $example['note'] ); ?></p>
+                            <?php endif; ?>
+                            <details>
+                                <summary><?php esc_html_e( 'Sample response', 'tcnapp-connector' ); ?></summary>
+                                <pre><?php echo esc_html( $example['response'] ); ?></pre>
+                            </details>
+                            <p>
+                                <button type="button" class="button button-secondary tcn-platform-api-example-fill"><?php esc_html_e( 'Load in tester', 'tcnapp-connector' ); ?></button>
+                            </p>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+            </div>
+        </div>
+        <?php
+    }
+
+    protected function prepare_url( string $endpoint ): string {
+        $endpoint = trim( $endpoint );
+
+        if ( '' === $endpoint ) {
+            return '';
+        }
+
+        if ( preg_match( '#^https?://#i', $endpoint ) ) {
+            return esc_url_raw( $endpoint );
+        }
+
+        if ( 0 === strpos( $endpoint, '//' ) ) {
+            $endpoint = 'https:' . $endpoint;
+            return esc_url_raw( $endpoint );
+        }
+
+        if ( 0 !== strpos( $endpoint, '/' ) ) {
+            $endpoint = '/' . $endpoint;
+        }
+
+        return home_url( $endpoint );
+    }
+
+    /**
+     * @param mixed $headers Raw headers from wp_remote_request.
+     *
+     * @return array<string, string>
+     */
+    protected function normalize_headers( $headers ): array {
+        if ( empty( $headers ) ) {
+            return array();
+        }
+
+        if ( is_object( $headers ) && method_exists( $headers, 'getAll' ) ) {
+            $headers = $headers->getAll();
+        }
+
+        if ( ! is_array( $headers ) ) {
+            return array();
+        }
+
+        $normalized = array();
+        foreach ( $headers as $key => $value ) {
+            if ( is_array( $value ) ) {
+                $normalized[ (string) $key ] = implode( ', ', array_map( 'strval', $value ) );
+            } else {
+                $normalized[ (string) $key ] = (string) $value;
+            }
+        }
+
+        ksort( $normalized );
+
+        return $normalized;
+    }
+
+    protected function format_body_for_display( string $body ): string {
+        $decoded = json_decode( $body, true );
+        if ( null !== $decoded && JSON_ERROR_NONE === json_last_error() ) {
+            $pretty = wp_json_encode( $decoded, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+            if ( $pretty ) {
+                return $pretty;
+            }
+        }
+
+        return $body;
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    protected function get_examples(): array {
+        $login_url     = home_url( '/wp-json/gn/v1/login' );
+        $register_url  = home_url( '/wp-json/gn/v1/register' );
+        $plans_url     = home_url( '/wp-json/gn/v1/memberships/plans' );
+        $customer_url  = home_url( '/wp-json/gn/v1/customers' );
+
+        return array(
+            array(
+                'method'     => 'POST',
+                'url'        => $login_url,
+                'description'=> __( 'Authenticate a user with the Password Login API module.', 'tcnapp-connector' ),
+                'note'       => __( 'Requires valid WordPress user credentials.', 'tcnapp-connector' ),
+                'headers'    => wp_json_encode( array( 'Content-Type' => 'application/json' ), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ?: '',
+                'body'       => wp_json_encode(
+                    array(
+                        'username' => 'demo@example.com',
+                        'password' => 'secret-password',
+                    ),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                ) ?: '',
+                'response'   => wp_json_encode(
+                    array(
+                        'success'    => true,
+                        'token'      => 'example-token',
+                        'expires_in' => 900,
+                        'redirect'   => $login_url,
+                    ),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                ) ?: '',
+            ),
+            array(
+                'method'      => 'POST',
+                'url'         => $register_url,
+                'description' => __( 'Create a new account using the registration endpoint.', 'tcnapp-connector' ),
+                'note'        => __( 'Open endpoint; validation rules from WordPress apply.', 'tcnapp-connector' ),
+                'headers'     => wp_json_encode( array( 'Content-Type' => 'application/json' ), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ?: '',
+                'body'        => wp_json_encode(
+                    array(
+                        'username'   => 'newuser',
+                        'email'      => 'newuser@example.com',
+                        'password'   => 'ChooseAStrongPassword!',
+                        'first_name' => 'Taylor',
+                        'last_name'  => 'Jordan',
+                    ),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                ) ?: '',
+                'response'    => wp_json_encode(
+                    array(
+                        'success' => true,
+                        'user_id' => 123,
+                        'message' => __( 'Registration successful.', 'tcnapp-connector' ),
+                    ),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                ) ?: '',
+            ),
+            array(
+                'method'      => 'GET',
+                'url'         => $plans_url,
+                'description' => __( 'Retrieve active membership plans exposed by the plugin.', 'tcnapp-connector' ),
+                'note'        => __( 'Public endpoint returning plan metadata.', 'tcnapp-connector' ),
+                'headers'     => '',
+                'body'        => '',
+                'response'    => wp_json_encode(
+                    array(
+                        'plans' => array(
+                            array(
+                                'id'          => 'blue',
+                                'name'        => 'Blue Membership',
+                                'price'       => '19.00',
+                                'description' => 'Entry level membership tier.',
+                            ),
+                        ),
+                    ),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                ) ?: '',
+            ),
+            array(
+                'method'      => 'GET',
+                'url'         => $customer_url . '?email=customer%40example.com',
+                'description' => __( 'Look up a WooCommerce customer by email address.', 'tcnapp-connector' ),
+                'note'        => __( 'Requires WooCommerce REST authentication (consumer key/secret).', 'tcnapp-connector' ),
+                'headers'     => wp_json_encode(
+                    array(
+                        'Authorization' => 'Basic base64encodedcredentials',
+                    ),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                ) ?: '',
+                'body'        => '',
+                'response'    => wp_json_encode(
+                    array(
+                        'id'         => 456,
+                        'email'      => 'customer@example.com',
+                        'first_name' => 'Sky',
+                        'last_name'  => 'River',
+                    ),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                ) ?: '',
+            ),
+        );
+    }
+
+    protected function abbreviate_url( string $url ): string {
+        $parsed = wp_parse_url( $url );
+        if ( empty( $parsed ) ) {
+            return $url;
+        }
+
+        $path  = isset( $parsed['path'] ) ? $parsed['path'] : '';
+        $query = isset( $parsed['query'] ) ? '?' . $parsed['query'] : '';
+
+        if ( '' === $path ) {
+            return $url;
+        }
+
+        return $path . $query;
+    }
+}

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -2,6 +2,7 @@
 namespace TCN\Platform;
 
 use TCN\Platform\Admin\Assets;
+use TCN\Platform\Admin\ApiTesterPage;
 use TCN\Platform\Admin\LogPage;
 use TCN\Platform\Admin\SettingsPage;
 use TCN\Platform\Auth\PasswordLoginService;
@@ -61,6 +62,7 @@ class Plugin {
         if ( is_admin() ) {
             $this->services[] = new SettingsPage( $this->modules );
             $this->services[] = new LogPage();
+            $this->services[] = new ApiTesterPage();
             $this->services[] = new Assets();
         }
     }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.19
+Stable tag: 0.3.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -61,6 +61,10 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.20 =
+* New API Tester admin submenu that lets administrators compose REST calls, inspect responses, and troubleshoot connectivity without leaving WordPress.
+* Bundled Postman-style examples showcasing common authentication and membership requests, complete with sample payloads and expected results.
+
 = 0.3.19 =
 * Enhancement: Allow WooCommerce REST API consumer keys to authenticate `gn/v1` customer and order endpoints for trusted integrators.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.19
+ * Version:           0.3.20
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.19' );
+define( 'TCN_PLATFORM_VERSION', '0.3.20' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- add an API Tester submenu so administrators can craft and send REST calls from within WordPress and review responses inline
- style and script the tester UI, including example presets that prefill the form for common requests
- bump the plugin version to 0.3.20 and document the new capability in the changelog

## Testing
- php -l includes/Admin/ApiTesterPage.php

------
https://chatgpt.com/codex/tasks/task_e_68e14d1e93548327b92556cdd4f55352