### PR TITLE
Bump plugin version to 0.3.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.22
+- Maintenance release to bump the plugin version for distribution.
+
 ### 0.3.21
 - Maintenance release to bump the plugin version for distribution.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.21
+Stable tag: 0.3.22
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -61,8 +61,8 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
-= 0.3.21 =
-* Maintenance: Bump the plugin version for the 0.3.21 release.
+= 0.3.22 =
+* Maintenance: Bump the plugin version for the 0.3.22 release.
 
 = 0.3.20 =
 * New API Tester admin submenu that lets administrators compose REST calls, inspect responses, and troubleshoot connectivity without leaving WordPress.

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.21
+ * Version:           0.3.22
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.21' );
+define( 'TCN_PLATFORM_VERSION', '0.3.22' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- update the plugin header and internal constant to version 0.3.22
- refresh stable tag and changelog entries to reference the new release number

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e15687adb08327ac89d84bee099ee1