### PR TITLE
Suppress new user notification emails for API registrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.23
+- Suppress default WordPress new user notification emails when registrations are created through the Password Login API so the app no longer triggers duplicate notices.
+
 ### 0.3.22
 - Maintenance release to bump the plugin version for distribution.
 

--- a/includes/Auth/PasswordLoginService.php
+++ b/includes/Auth/PasswordLoginService.php
@@ -165,7 +165,17 @@ class PasswordLoginService {
             return new WP_Error( 'gn_email_exists', __( 'This email address is already registered.', 'tcnapp-connector' ), array( 'status' => 409 ) );
         }
 
+        $suppress_new_user_notification = static function( $send ) {
+            return false;
+        };
+
+        add_filter( 'wp_send_new_user_notification_to_admin', $suppress_new_user_notification );
+        add_filter( 'wp_send_new_user_notification_to_user', $suppress_new_user_notification );
+
         $user_id = wp_create_user( $username, $password, $email );
+
+        remove_filter( 'wp_send_new_user_notification_to_admin', $suppress_new_user_notification );
+        remove_filter( 'wp_send_new_user_notification_to_user', $suppress_new_user_notification );
         if ( is_wp_error( $user_id ) ) {
             return new WP_Error( 'gn_registration_failed', __( 'Unable to create the user at this time.', 'tcnapp-connector' ), array( 'status' => 500 ) );
         }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.22
+Stable tag: 0.3.23
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -61,6 +61,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.23 =
+* Fix: Suppress default WordPress new user notification emails when registrations flow through the Password Login API.
+
 = 0.3.22 =
 * Maintenance: Bump the plugin version for the 0.3.22 release.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.22
+ * Version:           0.3.23
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.22' );
+define( 'TCN_PLATFORM_VERSION', '0.3.23' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- prevent WordPress from emailing admins or users when accounts are created through the Password Login API
- bump the plugin version to 0.3.23 and document the release notes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e158d68eac8327a4e18def55cf1e77