### PR TITLE
Fix membership plan product ID fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.25
+- Ensure the membership plans endpoint returns the correct WooCommerce product IDs by falling back to the official product slugs for each tier.
+
 ### 0.3.24
 - Add an exhaustive reference manual that documents every public class method and REST endpoint, including WooCommerce routes, with example payloads tailored for the built-in API tester.
 - Expand the admin API tester presets so every endpoint can be exercised without leaving the dashboard.

--- a/docs/TCN_PLATFORM_REFERENCE.md
+++ b/docs/TCN_PLATFORM_REFERENCE.md
@@ -232,7 +232,7 @@ The tables below enumerate every method, its visibility, parameters, return valu
 | `assign_sponsor_from_cookie( int $user_id )` | public | Applies sponsor cookie to new registrations, updates metrics. | `$user_id` | void | Hooked to `user_register`. |
 | `ensure_customer_role( int $user_id )` | protected | Adds WooCommerce `customer` role, removes `subscriber` when redundant. | `$user_id` | void | — |
 | `maybe_create_welcome_order( int $user_id, WP_REST_Request $request )` | protected | Auto-creates completed WooCommerce order for Blue tier on API signup. | `$user_id`, `$request` | void | Stores order ID in user meta. |
-| `get_membership_product_id( string $level )` | protected | Resolves product ID for membership level, with slug fallback. | `$level` | int | Prefers mapping from `get_membership_products()`. |
+| `get_membership_product_id( string $level, ?array $products = null )` | protected | Resolves product ID for membership level, with slug fallback. | `$level`, optional product map | int | Prefers mapping from `get_membership_products()`, falls back to known slugs (`blue-membership`, `gold-membership`, etc.). |
 | `get_product_id_by_slug( string $slug )` | protected | Finds product by slug. | `$slug` | int | Returns 0 when not found. |
 | `ensure_sponsor_assignment( int $user_id )` | protected | Ensures user has sponsor via cookie/default setting, updates metrics. | `$user_id` | void | — |
 | `record_commissions( int $member_id, int $order_id, string $level_key )` | protected | Inserts direct and passive commission rows, updates recruit counts. | Member ID, order ID, level key. | void | Writes to custom table. |

--- a/includes/Membership/MembershipModule.php
+++ b/includes/Membership/MembershipModule.php
@@ -388,7 +388,7 @@ class MembershipModule {
                 'benefits'           => $benefits,
                 'commission_direct'  => isset( $level['commission_direct'] ) ? (float) $level['commission_direct'] : 0.0,
                 'commission_passive' => isset( $level['commission_passive'] ) ? (float) $level['commission_passive'] : 0.0,
-                'product_id'         => isset( $products[ $key ] ) ? (int) $products[ $key ] : 0,
+                'product_id'         => $this->get_membership_product_id( (string) $key, $products ),
             );
 
             $plan['requires_payment'] = $plan['fee'] > 0;
@@ -798,15 +798,30 @@ class MembershipModule {
     /**
      * Retrieve the WooCommerce product ID associated with a membership level.
      */
-    protected function get_membership_product_id( string $level ): int {
-        $products = $this->get_membership_products();
+    protected function get_membership_product_id( string $level, ?array $products = null ): int {
+        $level = sanitize_key( $level );
+
+        if ( '' === $level ) {
+            return 0;
+        }
+
+        if ( null === $products ) {
+            $products = $this->get_membership_products();
+        }
 
         if ( isset( $products[ $level ] ) ) {
             return (int) $products[ $level ];
         }
 
-        if ( 'blue' === $level ) {
-            $fallback = $this->get_product_id_by_slug( 'blue-membership' );
+        $fallback_slugs = array(
+            'blue'     => 'blue-membership',
+            'gold'     => 'gold-membership',
+            'platinum' => 'platinum-membership',
+            'black'    => 'black-membership',
+        );
+
+        if ( isset( $fallback_slugs[ $level ] ) ) {
+            $fallback = $this->get_product_id_by_slug( $fallback_slugs[ $level ] );
 
             if ( $fallback > 0 ) {
                 return $fallback;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.24
+Stable tag: 0.3.25
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.24
+ * Version:           0.3.25
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.24' );
+define( 'TCN_PLATFORM_VERSION', '0.3.25' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- ensure the membership plans REST response resolves WooCommerce products with slug-based fallbacks for every tier
- document the updated helper signature and add release notes for version 0.3.25
- bump the plugin metadata and stable tag to version 0.3.25

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e173a629508327a224d6294d72a87d