### PR TITLE
Fix membership plan pricing truncation and release 0.3.27

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.27
+- Read membership pricing directly from WooCommerce product meta so third-party price filters no longer downscale the fees surfaced to the mobile app.
+
 ### 0.3.26
 - Restore numeric membership pricing in the mobile plans endpoint and expose formatted amounts so the app no longer renders "THBNaN" labels.
 

--- a/includes/Support/Options.php
+++ b/includes/Support/Options.php
@@ -151,14 +151,22 @@ class Options {
                 continue;
             }
 
-            $price = $product->get_price( 'edit' );
+            $price = $product->get_meta( '_price', true );
 
             if ( '' === $price ) {
-                $price = $product->get_regular_price( 'edit' );
+                $price = $product->get_meta( '_regular_price', true );
+            }
+
+            if ( '' === $price ) {
+                $price = $product->get_price( 'edit' );
             }
 
             if ( '' === $price ) {
                 $price = 0;
+            }
+
+            if ( is_string( $price ) && function_exists( 'wc_clean' ) ) {
+                $price = wc_clean( $price );
             }
 
             if ( function_exists( 'wc_format_decimal' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.26
+Stable tag: 0.3.27
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -61,6 +61,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.27 =
+* Fix: Read membership product pricing directly from the WooCommerce post meta to prevent filtered values from truncating fees in the mobile plans API.
+
 = 0.3.26 =
 * Fix: Restore numeric pricing in the membership plans API response and expose formatted amounts to prevent "THBNaN" labels in the mobile app.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.26
+ * Version:           0.3.27
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.26' );
+define( 'TCN_PLATFORM_VERSION', '0.3.27' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- load membership product fees directly from WooCommerce post meta so filtered price hooks no longer downscale the mobile plans API output
- bump the plugin version to 0.3.27 and document the release notes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1783175048327b6f5ae03f5f563a0