### PR TITLE
Normalize THB membership fee parsing from WooCommerce metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.28
+- Normalise WooCommerce-derived membership fees so THB prices retain the expected zeros when thousand separators are configured.
+
 ### 0.3.27
 - Read membership pricing directly from WooCommerce product meta so third-party price filters no longer downscale the fees surfaced to the mobile app.
 

--- a/includes/Support/Options.php
+++ b/includes/Support/Options.php
@@ -61,7 +61,8 @@ class Options {
             );
 
             $level['slug']     = $slug;
-            $normalized[ $slug ] = wp_parse_args( $level, $base );
+            $normalized_level  = wp_parse_args( $level, $base );
+            $normalized[ $slug ] = self::normalize_level_amounts( $normalized_level );
         }
 
         $levels = array_replace( $defaults, $normalized );
@@ -161,22 +162,88 @@ class Options {
                 $price = $product->get_price( 'edit' );
             }
 
-            if ( '' === $price ) {
-                $price = 0;
-            }
-
-            if ( is_string( $price ) && function_exists( 'wc_clean' ) ) {
-                $price = wc_clean( $price );
-            }
-
-            if ( function_exists( 'wc_format_decimal' ) ) {
-                $price = wc_format_decimal( $price );
-            }
-
-            $levels[ $level_key ]['fee'] = (float) $price;
+            $levels[ $level_key ]['fee'] = self::parse_currency_amount( $price );
         }
 
         return $levels;
+    }
+
+    /**
+     * Normalize numeric fields on a membership level definition.
+     *
+     * @param array<string, mixed> $level
+     *
+     * @return array<string, mixed>
+     */
+    protected static function normalize_level_amounts( array $level ): array {
+        foreach ( array( 'fee', 'commission_direct', 'commission_passive' ) as $key ) {
+            if ( isset( $level[ $key ] ) ) {
+                $level[ $key ] = self::parse_currency_amount( $level[ $key ] );
+            }
+        }
+
+        if ( isset( $level['commission_direct_overrides'] ) && is_array( $level['commission_direct_overrides'] ) ) {
+            foreach ( $level['commission_direct_overrides'] as $override_key => $value ) {
+                $level['commission_direct_overrides'][ $override_key ] = self::parse_currency_amount( $value );
+            }
+        }
+
+        return $level;
+    }
+
+    /**
+     * Convert currency strings (with locale separators) into floats.
+     *
+     * @param mixed $value
+     */
+    protected static function parse_currency_amount( $value ): float {
+        if ( is_numeric( $value ) ) {
+            return (float) $value;
+        }
+
+        if ( is_string( $value ) ) {
+            if ( function_exists( 'wc_format_decimal' ) ) {
+                $normalized = wc_format_decimal( $value, false, false );
+                if ( is_numeric( $normalized ) ) {
+                    return (float) $normalized;
+                }
+            }
+
+            $value = html_entity_decode( $value, ENT_QUOTES, 'UTF-8' );
+
+            if ( function_exists( 'wc_clean' ) ) {
+                $value = wc_clean( $value );
+            }
+
+            $value = preg_replace( '/[^0-9\.,-]/u', '', (string) $value );
+
+            if ( '' === $value ) {
+                return 0.0;
+            }
+
+            $thousand = function_exists( 'wc_get_price_thousand_separator' ) ? wc_get_price_thousand_separator() : ',';
+            $decimal  = function_exists( 'wc_get_price_decimal_separator' ) ? wc_get_price_decimal_separator() : '.';
+
+            if ( '' !== $thousand ) {
+                $value = str_replace( $thousand, '', $value );
+            }
+
+            if ( '.' !== $decimal && false !== strpos( $value, $decimal ) ) {
+                $value = str_replace( $decimal, '.', $value );
+            }
+
+            $parts = explode( '.', $value );
+            if ( count( $parts ) > 2 ) {
+                $last  = array_pop( $parts );
+                $value = implode( '', $parts ) . '.' . $last;
+            }
+
+            if ( is_numeric( $value ) ) {
+                return (float) $value;
+            }
+        }
+
+        return 0.0;
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.27
+Stable tag: 0.3.28
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -61,6 +61,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.28 =
+* Fix: Normalise membership fees loaded from WooCommerce so THB pricing keeps its trailing zeros when thousand separators are enabled.
+
 = 0.3.27 =
 * Fix: Read membership product pricing directly from the WooCommerce post meta to prevent filtered values from truncating fees in the mobile plans API.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.27
+ * Version:           0.3.28
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.27' );
+define( 'TCN_PLATFORM_VERSION', '0.3.28' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- normalise membership level amounts when loading options so THB fees retain their zeros despite WooCommerce thousand separators
- parse WooCommerce product prices with locale-aware helpers before exposing plan fees
- bump the plugin version to 0.3.28 and document the release notes

## Testing
- php -l includes/Support/Options.php

------
https://chatgpt.com/codex/tasks/task_e_68e179d6542883279465c68253ced4bf