### PR TITLE
Protect admin monitoring tools with password gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.29
+- Lock the Activity Log and API Tester admin pages behind a non-public password challenge that expires every 24 hours per administrator session.
+
 ### 0.3.28
 - Normalise WooCommerce-derived membership fees so THB prices retain the expected zeros when thousand separators are configured.
 

--- a/includes/Admin/ApiTesterPage.php
+++ b/includes/Admin/ApiTesterPage.php
@@ -51,6 +51,10 @@ class ApiTesterPage {
             wp_die( esc_html__( 'You do not have permission to access this page.', 'tcnapp-connector' ) );
         }
 
+        if ( ! RestrictedAccess::require_access( 'tcn-platform-api-tester', __( 'API Tester', 'tcnapp-connector' ) ) ) {
+            return;
+        }
+
         $method        = 'GET';
         $endpoint      = '';
         $headers_input = '';

--- a/includes/Admin/LogPage.php
+++ b/includes/Admin/LogPage.php
@@ -53,6 +53,10 @@ class LogPage {
             wp_die( esc_html__( 'Invalid request.', 'tcnapp-connector' ) );
         }
 
+        if ( ! RestrictedAccess::has_access( 'tcn-platform-logs' ) ) {
+            wp_die( esc_html__( 'Please unlock the Activity Log before performing this action.', 'tcnapp-connector' ) );
+        }
+
         $actor       = wp_get_current_user();
         $actor_label = ( $actor && $actor->ID ) ? $actor->user_login : __( 'Unknown user', 'tcnapp-connector' );
 
@@ -77,6 +81,10 @@ class LogPage {
     public function render_page(): void {
         if ( ! current_user_can( 'manage_options' ) ) {
             wp_die( esc_html__( 'You do not have permission to access this page.', 'tcnapp-connector' ) );
+        }
+
+        if ( ! RestrictedAccess::require_access( 'tcn-platform-logs', __( 'Activity Log', 'tcnapp-connector' ) ) ) {
+            return;
         }
 
         $logs = Logger::get_logs();

--- a/includes/Admin/RestrictedAccess.php
+++ b/includes/Admin/RestrictedAccess.php
@@ -1,0 +1,141 @@
+<?php
+namespace TCN\Platform\Admin;
+
+use function admin_url;
+use function check_admin_referer;
+use function current_time;
+use function esc_html;
+use function esc_html_e;
+use function get_current_user_id;
+use function get_user_meta;
+use function hash_equals;
+use function is_array;
+use function password_verify;
+use function update_user_meta;
+use function wp_nonce_field;
+use function wp_safe_redirect;
+use function wp_unslash;
+
+class RestrictedAccess {
+    private const PASSWORD_HASH = '$2y$12$Kzw1Fft2LS/UNVNebCRL2.7gkjrRVL5j6ObyqsEsOTtH6KRoY1uqO';
+
+    private const META_KEY = '_tcn_platform_restricted_access';
+
+    private const NONCE_ACTION = 'tcn_platform_unlock';
+
+    private const NONCE_NAME = 'tcn_platform_unlock_nonce';
+
+    private const EXPIRATION_SECONDS = 86400; // 24 hours.
+
+    public static function require_access( string $page_slug, string $page_title ): bool {
+        if ( self::has_access( $page_slug ) ) {
+            return true;
+        }
+
+        $error = false;
+
+        if ( 'POST' === $_SERVER['REQUEST_METHOD'] && isset( $_POST[ self::NONCE_NAME ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            check_admin_referer( self::NONCE_ACTION, self::NONCE_NAME );
+
+            $password = isset( $_POST['tcn_platform_password'] ) ? (string) wp_unslash( $_POST['tcn_platform_password'] ) : '';
+
+            if ( self::verify_password( $password ) ) {
+                self::grant_access( $page_slug );
+                wp_safe_redirect( admin_url( 'admin.php?page=' . $page_slug ) );
+                exit;
+            }
+
+            $error = true;
+        }
+
+        self::render_lock_screen( $page_title, $error );
+
+        return false;
+    }
+
+    public static function has_access( string $page_slug ): bool {
+        $user_id = get_current_user_id();
+
+        if ( ! $user_id ) {
+            return false;
+        }
+
+        $tokens = get_user_meta( $user_id, self::META_KEY, true );
+        if ( ! is_array( $tokens ) ) {
+            return false;
+        }
+
+        $token = self::tokenize( $page_slug );
+        if ( ! isset( $tokens[ $token ] ) ) {
+            return false;
+        }
+
+        $expires = isset( $tokens[ $token ]['expires'] ) ? (int) $tokens[ $token ]['expires'] : 0;
+
+        if ( $expires < current_time( 'timestamp', true ) ) {
+            unset( $tokens[ $token ] );
+            update_user_meta( $user_id, self::META_KEY, $tokens );
+            return false;
+        }
+
+        return hash_equals( $token, $tokens[ $token ]['token'] ?? '' );
+    }
+
+    private static function grant_access( string $page_slug ): void {
+        $user_id = get_current_user_id();
+
+        if ( ! $user_id ) {
+            return;
+        }
+
+        $tokens = get_user_meta( $user_id, self::META_KEY, true );
+        if ( ! is_array( $tokens ) ) {
+            $tokens = array();
+        }
+
+        $token = self::tokenize( $page_slug );
+
+        $tokens[ $token ] = array(
+            'token'   => $token,
+            'expires' => current_time( 'timestamp', true ) + self::EXPIRATION_SECONDS,
+        );
+
+        update_user_meta( $user_id, self::META_KEY, $tokens );
+    }
+
+    private static function verify_password( string $password ): bool {
+        if ( '' === $password ) {
+            return false;
+        }
+
+        return password_verify( $password, self::PASSWORD_HASH );
+    }
+
+    private static function render_lock_screen( string $page_title, bool $error ): void {
+        ?>
+        <div class="wrap tcn-platform-locked">
+            <h1><?php echo esc_html( $page_title ); ?></h1>
+            <p class="description"><?php esc_html_e( 'This area is restricted. Provide the access password to continue.', 'tcnapp-connector' ); ?></p>
+
+            <?php if ( $error ) : ?>
+                <div class="notice notice-error">
+                    <p><?php esc_html_e( 'Incorrect password. Please try again.', 'tcnapp-connector' ); ?></p>
+                </div>
+            <?php endif; ?>
+
+            <form method="post">
+                <?php wp_nonce_field( self::NONCE_ACTION, self::NONCE_NAME ); ?>
+                <label for="tcn-platform-password" class="screen-reader-text"><?php esc_html_e( 'Access password', 'tcnapp-connector' ); ?></label>
+                <input type="password" id="tcn-platform-password" name="tcn_platform_password" class="regular-text" autocomplete="off" />
+                <p>
+                    <button type="submit" class="button button-primary"><?php esc_html_e( 'Unlock', 'tcnapp-connector' ); ?></button>
+                </p>
+            </form>
+        </div>
+        <?php
+    }
+
+    private static function tokenize( string $page_slug ): string {
+        return hash( 'sha256', $page_slug . '|' . self::PASSWORD_HASH );
+    }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.28
+Stable tag: 0.3.29
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -61,6 +61,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.29 =
+* Security: Gate the Activity Log and API Tester admin tools behind a password-protected prompt that expires every 24 hours per administrator.
+
 = 0.3.28 =
 * Fix: Normalise membership fees loaded from WooCommerce so THB pricing keeps its trailing zeros when thousand separators are enabled.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.28
+ * Version:           0.3.29
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.28' );
+define( 'TCN_PLATFORM_VERSION', '0.3.29' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- add a reusable RestrictedAccess helper that validates a hashed admin password and stores 24-hour unlock tokens per user
- require the Activity Log (including the clear action) and API Tester admin pages to be unlocked before use
- bump the plugin version to 0.3.29 and document the gated access in the readme files

## Testing
- php -l includes/Admin/ApiTesterPage.php
- php -l includes/Admin/LogPage.php
- php -l includes/Admin/RestrictedAccess.php

------
https://chatgpt.com/codex/tasks/task_e_68e17c0158ec8327855db5fca584841a