### PR TITLE
Add membership product mapping controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.30
+- Allow administrators to map WooCommerce products to membership levels from the settings screen, persist the selections in plugin options, and keep the `_tcn_membership_level` meta in sync for reliable upgrades even when product slugs change.
+
 ### 0.3.29
 - Lock the Activity Log and API Tester admin pages behind a non-public password challenge that expires every 24 hours per administrator session.
 

--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -66,7 +66,28 @@ class SettingsPage {
             ? sanitize_text_field( wp_unslash( $_POST['stripe_secret_key'] ) )
             : '';
 
+        $membership_products = array();
+        if ( isset( $_POST['membership_products'] ) && is_array( $_POST['membership_products'] ) ) {
+            $raw_products = wp_unslash( $_POST['membership_products'] );
+
+            foreach ( Options::get_levels() as $level ) {
+                if ( empty( $level['slug'] ) ) {
+                    continue;
+                }
+
+                $slug       = sanitize_key( (string) $level['slug'] );
+                $product_id = isset( $raw_products[ $slug ] ) ? absint( $raw_products[ $slug ] ) : 0;
+
+                if ( $slug && $product_id > 0 ) {
+                    $membership_products[ $slug ] = $product_id;
+                }
+            }
+        }
+
+        $general_settings['membership_products'] = $membership_products;
+
         Options::update_general_settings( $general_settings );
+        $this->sync_membership_product_meta( $membership_products );
 
         do_action( 'tcn_platform_settings_saved', $modules, $login );
 
@@ -81,6 +102,7 @@ class SettingsPage {
         $modules        = $this->modules->all();
         $login_settings = Options::get_login_settings();
         $levels         = Options::get_levels();
+        $product_map    = Options::get_membership_product_map();
 
         if ( ! is_array( $levels ) ) {
             $levels = array();
@@ -89,6 +111,7 @@ class SettingsPage {
         $currency       = isset( $general['currency'] ) ? $general['currency'] : 'USD';
         $publishable    = isset( $general['stripe_publishable_key'] ) ? $general['stripe_publishable_key'] : '';
         $secret         = isset( $general['stripe_secret_key'] ) ? $general['stripe_secret_key'] : '';
+        $product_options = $this->get_membership_product_options();
 
         settings_errors( 'tcn_platform' );
         ?>
@@ -189,6 +212,54 @@ class SettingsPage {
                     </tbody>
                 </table>
 
+                <h2><?php esc_html_e( 'Membership Products', 'tcnapp-connector' ); ?></h2>
+                <p class="description"><?php esc_html_e( 'Select the WooCommerce products that correspond to each membership plan. These mappings ensure upgrades keep working even if product titles or slugs change.', 'tcnapp-connector' ); ?></p>
+                <table class="form-table" role="presentation">
+                    <tbody>
+                        <?php if ( empty( $product_options ) && ! function_exists( 'wc_get_products' ) ) : ?>
+                            <tr>
+                                <th scope="row"><?php esc_html_e( 'Membership Products', 'tcnapp-connector' ); ?></th>
+                                <td>
+                                    <p class="description"><?php esc_html_e( 'Install and activate WooCommerce to assign products to membership levels.', 'tcnapp-connector' ); ?></p>
+                                </td>
+                            </tr>
+                        <?php else : ?>
+                            <?php foreach ( $levels as $level ) :
+                                if ( empty( $level['slug'] ) ) {
+                                    continue;
+                                }
+
+                                $slug      = sanitize_key( (string) $level['slug'] );
+                                $selected  = isset( $product_map[ $slug ] ) ? (int) $product_map[ $slug ] : 0;
+                                $label     = isset( $level['name'] ) ? (string) $level['name'] : $slug;
+                                $options   = $product_options;
+
+                                if ( $selected > 0 && ! isset( $options[ $selected ] ) ) {
+                                    /* translators: %d: WooCommerce product ID */
+                                    $options[ $selected ] = sprintf( __( 'Product #%d (not found)', 'tcnapp-connector' ), $selected );
+                                }
+                                ?>
+                                <tr>
+                                    <th scope="row">
+                                        <label for="membership_products_<?php echo esc_attr( $slug ); ?>"><?php echo esc_html( $label ); ?></label>
+                                    </th>
+                                    <td>
+                                        <?php if ( empty( $options ) ) : ?>
+                                            <p class="description"><?php esc_html_e( 'Create WooCommerce products to enable membership mapping.', 'tcnapp-connector' ); ?></p>
+                                        <?php else : ?>
+                                            <select id="membership_products_<?php echo esc_attr( $slug ); ?>" name="membership_products[<?php echo esc_attr( $slug ); ?>]">
+                                                <?php foreach ( $options as $product_id => $product_label ) : ?>
+                                                    <option value="<?php echo esc_attr( $product_id ); ?>" <?php selected( $selected, $product_id ); ?>><?php echo esc_html( $product_label ); ?></option>
+                                                <?php endforeach; ?>
+                                            </select>
+                                        <?php endif; ?>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+
                 <?php submit_button(); ?>
             </form>
 
@@ -247,5 +318,103 @@ class SettingsPage {
         }
 
         return sprintf( '%s %.2f', $currency, (float) $amount );
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function get_membership_product_options(): array {
+        if ( ! function_exists( 'wc_get_products' ) ) {
+            return array();
+        }
+
+        $products = wc_get_products(
+            array(
+                'limit'  => -1,
+                'status' => array( 'publish', 'pending', 'draft' ),
+                'return'  => 'objects',
+                'orderby' => 'title',
+                'order'   => 'ASC',
+            )
+        );
+
+        if ( empty( $products ) ) {
+            return array();
+        }
+
+        $options = array( 0 => __( '— Select —', 'tcnapp-connector' ) );
+
+        foreach ( $products as $product ) {
+            $options[ $product->get_id() ] = sprintf(
+                /* translators: 1: WooCommerce product name, 2: product ID */
+                __( '%1$s (#%2$d)', 'tcnapp-connector' ),
+                $product->get_name(),
+                $product->get_id()
+            );
+        }
+
+        return $options;
+    }
+
+    /**
+     * Synchronize the `_tcn_membership_level` product meta with the saved mappings.
+     *
+     * @param array<string, int> $mapping
+     */
+    protected function sync_membership_product_meta( array $mapping ): void {
+        if ( ! function_exists( 'wc_get_products' ) ) {
+            return;
+        }
+
+        $normalized = array();
+        foreach ( $mapping as $slug => $product_id ) {
+            $slug       = sanitize_key( (string) $slug );
+            $product_id = (int) $product_id;
+
+            if ( '' === $slug || $product_id <= 0 ) {
+                continue;
+            }
+
+            $normalized[ $slug ] = $product_id;
+        }
+
+        $reverse = array_flip( $normalized );
+
+        $existing_products = wc_get_products(
+            array(
+                'limit'      => -1,
+                'status'     => array( 'publish', 'pending', 'draft' ),
+                'meta_query' => array(
+                    array(
+                        'key'     => '_tcn_membership_level',
+                        'compare' => 'EXISTS',
+                    ),
+                ),
+                'return'     => 'ids',
+            )
+        );
+
+        if ( ! empty( $existing_products ) ) {
+            foreach ( $existing_products as $product_id ) {
+                $product_id = (int) $product_id;
+                $assigned   = get_post_meta( $product_id, '_tcn_membership_level', true );
+
+                if ( isset( $reverse[ $product_id ] ) ) {
+                    $slug = $reverse[ $product_id ];
+
+                    if ( $assigned !== $slug ) {
+                        update_post_meta( $product_id, '_tcn_membership_level', $slug );
+                    }
+
+                    continue;
+                }
+
+                delete_post_meta( $product_id, '_tcn_membership_level' );
+            }
+        }
+
+        foreach ( $normalized as $slug => $product_id ) {
+            update_post_meta( $product_id, '_tcn_membership_level', $slug );
+        }
     }
 }

--- a/includes/Membership/MembershipModule.php
+++ b/includes/Membership/MembershipModule.php
@@ -532,6 +532,35 @@ class MembershipModule {
      * @return array<string, int>
      */
     protected function get_membership_products(): array {
+        $mapping   = Options::get_membership_product_map();
+        $validated = array();
+
+        if ( ! empty( $mapping ) ) {
+            foreach ( $mapping as $slug => $product_id ) {
+                $product_id = (int) $product_id;
+
+                if ( $product_id <= 0 ) {
+                    continue;
+                }
+
+                if ( function_exists( 'wc_get_product' ) ) {
+                    $product = wc_get_product( $product_id );
+
+                    if ( ! $product ) {
+                        continue;
+                    }
+                } elseif ( ! get_post( $product_id ) ) {
+                    continue;
+                }
+
+                $validated[ $slug ] = $product_id;
+            }
+
+            if ( ! empty( $validated ) ) {
+                return $validated;
+            }
+        }
+
         if ( ! function_exists( 'wc_get_products' ) ) {
             return array();
         }

--- a/includes/Support/Options.php
+++ b/includes/Support/Options.php
@@ -90,6 +90,10 @@ class Options {
     }
 
     public static function update_general_settings( array $settings ): void {
+        if ( isset( $settings['membership_products'] ) && is_array( $settings['membership_products'] ) ) {
+            $settings['membership_products'] = self::normalize_membership_product_map( $settings['membership_products'] );
+        }
+
         update_option( self::OPTION_GENERAL, $settings );
     }
 
@@ -118,7 +122,39 @@ class Options {
      * @return array<string, array<string, mixed>>
      */
     protected static function apply_membership_product_fees( array $levels ): array {
-        if ( empty( $levels ) || ! function_exists( 'wc_get_products' ) ) {
+        if ( empty( $levels ) ) {
+            return $levels;
+        }
+
+        $assigned = self::get_membership_product_map();
+
+        if ( function_exists( 'wc_get_product' ) && ! empty( $assigned ) ) {
+            foreach ( $assigned as $slug => $product_id ) {
+                if ( ! isset( $levels[ $slug ] ) ) {
+                    continue;
+                }
+
+                $product = wc_get_product( $product_id );
+
+                if ( ! $product ) {
+                    continue;
+                }
+
+                $price = $product->get_price( 'edit' );
+
+                if ( '' === $price ) {
+                    $price = $product->get_regular_price( 'edit' );
+                }
+
+                if ( '' === $price ) {
+                    $price = $product->get_meta( '_price', true );
+                }
+
+                $levels[ $slug ]['fee'] = self::parse_currency_amount( $price );
+            }
+        }
+
+        if ( ! function_exists( 'wc_get_products' ) ) {
             return $levels;
         }
 
@@ -148,7 +184,7 @@ class Options {
 
             $level_key = sanitize_key( $level_key );
 
-            if ( '' === $level_key || ! isset( $levels[ $level_key ] ) ) {
+            if ( '' === $level_key || ! isset( $levels[ $level_key ] ) || isset( $assigned[ $level_key ] ) ) {
                 continue;
             }
 
@@ -317,7 +353,43 @@ class Options {
             'default_sponsor'        => 0,
             'stripe_publishable_key' => '',
             'stripe_secret_key'      => '',
+            'membership_products'    => array(),
         );
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public static function get_membership_product_map(): array {
+        $settings = self::get_general_settings();
+
+        if ( empty( $settings['membership_products'] ) || ! is_array( $settings['membership_products'] ) ) {
+            return array();
+        }
+
+        return self::normalize_membership_product_map( $settings['membership_products'] );
+    }
+
+    /**
+     * @param array<string, mixed> $mapping
+     *
+     * @return array<string, int>
+     */
+    protected static function normalize_membership_product_map( array $mapping ): array {
+        $normalized = array();
+
+        foreach ( $mapping as $slug => $product_id ) {
+            $slug       = sanitize_key( (string) $slug );
+            $product_id = (int) $product_id;
+
+            if ( '' === $slug || $product_id <= 0 ) {
+                continue;
+            }
+
+            $normalized[ $slug ] = $product_id;
+        }
+
+        return $normalized;
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.29
+Stable tag: 0.3.30
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -61,6 +61,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.30 =
+* Feature: Map WooCommerce products to membership plans directly from the settings page and keep the `_tcn_membership_level` meta synchronised so product slug changes no longer break upgrades.
+
 = 0.3.29 =
 * Security: Gate the Activity Log and API Tester admin tools behind a password-protected prompt that expires every 24 hours per administrator.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.29
+ * Version:           0.3.30
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.29' );
+define( 'TCN_PLATFORM_VERSION', '0.3.30' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- add membership product mapping controls on the TCN Platform settings page so admins can choose WooCommerce products per level
- store and normalise the selections in general settings, reuse them across membership lookups, and keep product meta in sync
- bump the plugin to version 0.3.30 and document the new capability in the changelog

## Testing
- php -l includes/Admin/SettingsPage.php
- php -l includes/Support/Options.php
- php -l includes/Membership/MembershipModule.php

------
https://chatgpt.com/codex/tasks/task_e_68e186f9663c8327b930b69e375267b2