### PR TITLE
Add WPML compatibility for membership strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.32
+- Register membership level labels and benefits with WPML so multilingual storefronts can translate TCN settings directly from the String Translation UI.
+
 ### 0.3.31
 - Expose commission controls on the admin settings screen so administrators can adjust direct and passive payouts per membership tier without editing code, keeping compensation programmes aligned with organisational changes.
 

--- a/includes/Support/Options.php
+++ b/includes/Support/Options.php
@@ -70,11 +70,17 @@ class Options {
         // Only expose the official tiers even if legacy data introduces stray keys.
         $levels = array_intersect_key( $levels, $defaults );
 
-        return self::apply_membership_product_fees( $levels );
+        $levels = self::apply_membership_product_fees( $levels );
+
+        WPML::register_membership_levels( $levels );
+
+        return WPML::translate_membership_levels( $levels );
     }
 
     public static function update_levels( array $levels ): void {
         update_option( self::OPTION_LEVELS, $levels );
+
+        WPML::register_membership_levels( $levels );
     }
 
     /**

--- a/includes/Support/WPML.php
+++ b/includes/Support/WPML.php
@@ -1,0 +1,121 @@
+<?php
+namespace TCN\Platform\Support;
+
+/**
+ * Lightweight helpers for WPML string registration and translation.
+ */
+class WPML {
+    const STRING_CONTEXT = 'tcnapp-connector';
+
+    /**
+     * Register membership level strings with WPML so administrators can translate them.
+     *
+     * @param array<string, array<string, mixed>> $levels
+     */
+    public static function register_membership_levels( array $levels ): void {
+        if ( ! self::is_active() ) {
+            return;
+        }
+
+        foreach ( $levels as $level ) {
+            if ( empty( $level['slug'] ) ) {
+                continue;
+            }
+
+            $slug = sanitize_key( (string) $level['slug'] );
+
+            if ( isset( $level['name'] ) && is_string( $level['name'] ) ) {
+                self::register_string( sprintf( 'membership_level_%s_name', $slug ), $level['name'] );
+            }
+
+            if ( ! empty( $level['benefits'] ) && is_array( $level['benefits'] ) ) {
+                $index = 0;
+
+                foreach ( $level['benefits'] as $benefit ) {
+                    if ( ! is_string( $benefit ) || '' === trim( $benefit ) ) {
+                        continue;
+                    }
+
+                    self::register_string(
+                        sprintf( 'membership_level_%s_benefit_%d', $slug, $index ),
+                        $benefit
+                    );
+
+                    $index++;
+                }
+            }
+        }
+    }
+
+    /**
+     * Translate membership level strings registered with WPML.
+     *
+     * @param array<string, array<string, mixed>> $levels
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public static function translate_membership_levels( array $levels ): array {
+        if ( ! self::is_active() ) {
+            return $levels;
+        }
+
+        foreach ( $levels as $key => $level ) {
+            if ( empty( $level['slug'] ) ) {
+                continue;
+            }
+
+            $slug = sanitize_key( (string) $level['slug'] );
+
+            if ( isset( $level['name'] ) && is_string( $level['name'] ) ) {
+                $levels[ $key ]['name'] = self::translate_string(
+                    sprintf( 'membership_level_%s_name', $slug ),
+                    $level['name']
+                );
+            }
+
+            if ( empty( $level['benefits'] ) || ! is_array( $level['benefits'] ) ) {
+                continue;
+            }
+
+            $translated_benefits = array();
+            $index               = 0;
+
+            foreach ( $level['benefits'] as $benefit ) {
+                if ( ! is_string( $benefit ) ) {
+                    $translated_benefits[] = $benefit;
+                    continue;
+                }
+
+                $translated_benefits[] = self::translate_string(
+                    sprintf( 'membership_level_%s_benefit_%d', $slug, $index ),
+                    $benefit
+                );
+
+                $index++;
+            }
+
+            $levels[ $key ]['benefits'] = $translated_benefits;
+        }
+
+        return $levels;
+    }
+
+    /**
+     * Determine whether WPML (or the String Translation module) is active.
+     */
+    protected static function is_active(): bool {
+        return defined( 'ICL_SITEPRESS_VERSION' )
+            || defined( 'WPML_ST_VERSION' )
+            || has_filter( 'wpml_translate_single_string' );
+    }
+
+    protected static function register_string( string $name, string $value ): void {
+        do_action( 'wpml_register_single_string', self::STRING_CONTEXT, $name, $value );
+    }
+
+    protected static function translate_string( string $name, string $value ): string {
+        $translated = apply_filters( 'wpml_translate_single_string', $value, self::STRING_CONTEXT, $name );
+
+        return is_string( $translated ) ? $translated : $value;
+    }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.31
+Stable tag: 0.3.32
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -61,6 +61,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.32 =
+* Compatibility: Register membership level names and benefits with WPML so multilingual sites can translate the settings without custom code.
+
 = 0.3.31 =
 * Feature: Configure direct and passive commission amounts for every membership tier without touching code, ensuring payouts align with changing compensation plans.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.31
+ * Version:           0.3.32
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.31' );
+define( 'TCN_PLATFORM_VERSION', '0.3.32' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- register membership level names and benefits with WPML so translations can be managed via String Translation
- wire the options loader to register and return translated strings
- bump the plugin version to 0.3.32 and document the release

## Testing
- php -l includes/Support/WPML.php
- php -l includes/Support/Options.php
- php -l tcnapp-connector.php

------
https://chatgpt.com/codex/tasks/task_e_68e18acb52288327abb6086a45f38119