### PR TITLE
Fix membership product availability lookup and release 0.3.33

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.33
+- Fix the membership product dropdown to honour every registered WooCommerce status so private or custom-state products appear instead of showing the "create products" warning.
+
 ### 0.3.32
 - Register membership level labels and benefits with WPML so multilingual storefronts can translate TCN settings directly from the String Translation UI.
 

--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -471,10 +471,16 @@ class SettingsPage {
             return array();
         }
 
+        $statuses = array_keys( wc_get_product_statuses() );
+
+        if ( empty( $statuses ) ) {
+            $statuses = array( 'publish', 'pending', 'draft', 'private' );
+        }
+
         $products = wc_get_products(
             array(
-                'limit'  => -1,
-                'status' => array( 'publish', 'pending', 'draft' ),
+                'limit'   => -1,
+                'status'  => $statuses,
                 'return'  => 'objects',
                 'orderby' => 'title',
                 'order'   => 'ASC',

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.32
+Stable tag: 0.3.33
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -61,6 +61,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.33 =
+* Fix: Load membership product options using every registered WooCommerce status so private or custom-state products appear in the mapping dropdown instead of triggering the "create products" warning.
+
 = 0.3.32 =
 * Compatibility: Register membership level names and benefits with WPML so multilingual sites can translate the settings without custom code.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.32
+ * Version:           0.3.33
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.32' );
+define( 'TCN_PLATFORM_VERSION', '0.3.33' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- load membership product options using all registered WooCommerce statuses so private or custom-state products appear in the mapping dropdown
- bump the plugin version to 0.3.33 and document the change in both readme files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e18d528efc8327b0f0cd33d1d4b92c