### PR TITLE
Guard WooCommerce helpers when building membership options

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.34
+- Prevent a fatal error on the settings screen when WooCommerce is unavailable by guarding membership product status lookups.
+
 ### 0.3.33
 - Fix the membership product dropdown to honour every registered WooCommerce status so private or custom-state products appear instead of showing the "create products" warning.
 

--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -471,13 +471,16 @@ class SettingsPage {
             return array();
         }
 
-        $statuses = array_keys( wc_get_product_statuses() );
+        $statuses = array();
+        if ( function_exists( 'wc_get_product_statuses' ) ) {
+            $statuses = array_keys( \wc_get_product_statuses() );
+        }
 
         if ( empty( $statuses ) ) {
             $statuses = array( 'publish', 'pending', 'draft', 'private' );
         }
 
-        $products = wc_get_products(
+        $products = \wc_get_products(
             array(
                 'limit'   => -1,
                 'status'  => $statuses,

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.33
+Stable tag: 0.3.34
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -61,6 +61,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.34 =
+* Fix: Prevent a fatal error on the settings screen when WooCommerce isn't available by guarding membership product status lookups.
+
 = 0.3.33 =
 * Fix: Load membership product options using every registered WooCommerce status so private or custom-state products appear in the mapping dropdown instead of triggering the "create products" warning.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.33
+ * Version:           0.3.34
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.33' );
+define( 'TCN_PLATFORM_VERSION', '0.3.34' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- prevent the settings screen from calling missing WooCommerce helpers by checking availability before fetching product statuses
- default to core statuses and continue loading membership product options even when WooCommerce functions are unavailable
- bump the plugin version and changelog entries to 0.3.34 for release

## Testing
- php -l includes/Admin/SettingsPage.php

------
https://chatgpt.com/codex/tasks/task_e_68e18ee29228832787992bdb7bdeac76