### PR TITLE
Fix membership product dropdown fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.35
+- Fall back to a direct WordPress product lookup when WooCommerce's product helper returns nothing so membership mapping always lists existing catalogue items.
+
 ### 0.3.34
 - Prevent a fatal error on the settings screen when WooCommerce is unavailable by guarding membership product status lookups.
 

--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -490,11 +490,11 @@ class SettingsPage {
             )
         );
 
-        if ( empty( $products ) ) {
-            return array();
+        if ( is_wp_error( $products ) ) {
+            $products = array();
         }
 
-        $options = array( 0 => __( '— Select —', 'tcnapp-connector' ) );
+        $options = array();
 
         foreach ( $products as $product ) {
             $options[ $product->get_id() ] = sprintf(
@@ -505,7 +505,53 @@ class SettingsPage {
             );
         }
 
-        return $options;
+        if ( empty( $options ) ) {
+            $product_posts = get_posts(
+                array(
+                    'post_type'      => 'product',
+                    'post_status'    => 'any',
+                    'posts_per_page' => -1,
+                    'orderby'        => 'title',
+                    'order'          => 'ASC',
+                    'fields'         => 'ids',
+                )
+            );
+
+            if ( ! empty( $product_posts ) ) {
+                foreach ( $product_posts as $product_id ) {
+                    $product_id = (int) $product_id;
+
+                    if ( $product_id <= 0 ) {
+                        continue;
+                    }
+
+                    $product = function_exists( 'wc_get_product' ) ? wc_get_product( $product_id ) : null;
+
+                    if ( $product && $product->is_type( 'variation' ) ) {
+                        continue;
+                    }
+
+                    $name = $product ? $product->get_name() : get_the_title( $product_id );
+
+                    if ( '' === $name ) {
+                        continue;
+                    }
+
+                    $options[ $product_id ] = sprintf(
+                        /* translators: 1: WooCommerce product name, 2: product ID */
+                        __( '%1$s (#%2$d)', 'tcnapp-connector' ),
+                        $name,
+                        $product_id
+                    );
+                }
+            }
+        }
+
+        if ( empty( $options ) ) {
+            return array();
+        }
+
+        return array( 0 => __( '— Select —', 'tcnapp-connector' ) ) + $options;
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.34
+Stable tag: 0.3.35
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -61,6 +61,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.35 =
+* Fix: Fall back to a direct WordPress product query when WooCommerce's product helper returns nothing so the membership mapping dropdown still lists existing catalogue items.
+
 = 0.3.34 =
 * Fix: Prevent a fatal error on the settings screen when WooCommerce isn't available by guarding membership product status lookups.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.34
+ * Version:           0.3.35
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.34' );
+define( 'TCN_PLATFORM_VERSION', '0.3.35' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- add a fallback WordPress product lookup so the membership mapping dropdown still lists catalogue items when `wc_get_products` returns nothing
- bump the plugin version to 0.3.35 and document the changelog entry

## Testing
- composer lint *(fails: command not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68e1909b3ab08327889963e02af771f7