### PR TITLE
Refresh admin UI styling and bump version to 0.3.36

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.36
+- Polish every admin screen with elevated cards, section panels, and richer typography so settings, logs, and the API tester feel cohesive and easier to scan.
+
 ### 0.3.35
 - Fall back to a direct WordPress product lookup when WooCommerce's product helper returns nothing so membership mapping always lists existing catalogue items.
 

--- a/admin/css/tcn-platform-admin.css
+++ b/admin/css/tcn-platform-admin.css
@@ -1,67 +1,480 @@
-.tcn-platform-settings {
-    max-width: 900px;
+.tcn-platform-settings,
+.tcn-platform-api-tester,
+.tcn-platform-logs {
+    --tcn-primary: #2563eb;
+    --tcn-primary-dark: #1d4ed8;
+    --tcn-surface: #ffffff;
+    --tcn-surface-muted: #f8fafc;
+    --tcn-border: #d8dee6;
+    --tcn-text: #1f2937;
+    --tcn-text-muted: #4b5563;
+    --tcn-radius-lg: 18px;
+    --tcn-radius-md: 12px;
+    --tcn-shadow-soft: 0 20px 45px rgba(15, 23, 42, 0.12);
+    color: var(--tcn-text);
 }
 
-.tcn-platform-settings h1 {
-    margin-bottom: 1.5rem;
+.wrap.tcn-platform-settings,
+.wrap.tcn-platform-api-tester,
+.wrap.tcn-platform-logs {
+    position: relative;
+    max-width: 1080px;
+    padding: 32px 36px 44px;
+    margin-top: 26px;
+    border-radius: calc(var(--tcn-radius-lg) + 6px);
+    background: linear-gradient(160deg, #eef2ff 0%, #f8fafc 30%, #ffffff 100%);
+    box-shadow: var(--tcn-shadow-soft);
+}
+
+.wrap.tcn-platform-settings::before,
+.wrap.tcn-platform-api-tester::before,
+.wrap.tcn-platform-logs::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    border: 1px solid rgba(37, 99, 235, 0.08);
+    pointer-events: none;
+}
+
+.tcn-platform-page-intro {
+    margin-bottom: 28px;
+}
+
+.tcn-platform-page-intro h1 {
+    margin-bottom: 8px;
+    font-size: 32px;
+    line-height: 1.2;
+    color: var(--tcn-text);
+}
+
+.tcn-platform-page-subtitle,
+.wrap .description.tcn-platform-page-subtitle {
+    max-width: 760px;
+    margin: 0;
+    font-size: 16px;
+    color: var(--tcn-text-muted);
 }
 
 .tcn-platform-card-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     gap: 20px;
-    margin-bottom: 2rem;
+    margin-bottom: 32px;
 }
 
 .tcn-platform-card {
-    background: #fff;
-    border: 1px solid #ccd0d4;
-    border-radius: 8px;
-    padding: 20px;
-    box-shadow: 0 2px 6px rgba(12, 38, 74, 0.06);
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 24px 24px 28px;
+    border-radius: var(--tcn-radius-md);
+    background: linear-gradient(155deg, rgba(37, 99, 235, 0.12), rgba(255, 255, 255, 0.9));
+    border: 1px solid rgba(37, 99, 235, 0.15);
+    box-shadow: 0 14px 28px rgba(15, 23, 42, 0.08);
 }
 
 .tcn-platform-card h2 {
-    margin-top: 0;
+    margin: 0;
     font-size: 18px;
+    font-weight: 700;
 }
 
 .tcn-platform-card p {
-    color: #555;
+    margin: 0;
+    color: var(--tcn-text-muted);
+}
+
+.tcn-platform-notice {
+    margin: 0;
+    padding: 10px 14px;
+    border-radius: 8px;
+    border: 1px dashed rgba(37, 99, 235, 0.35);
+    background: rgba(37, 99, 235, 0.08);
+    color: var(--tcn-primary-dark);
+    font-weight: 600;
+}
+
+.tcn-platform-section {
+    margin-bottom: 28px;
+    padding: 24px 28px;
+    border-radius: var(--tcn-radius-md);
+    background: var(--tcn-surface);
+    border: 1px solid var(--tcn-border);
+    box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+}
+
+.tcn-platform-section:last-of-type {
+    margin-bottom: 36px;
+}
+
+.tcn-platform-section-header {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-bottom: 18px;
+}
+
+.tcn-platform-section-header h2 {
+    margin: 0;
+    font-size: 21px;
+    line-height: 1.3;
+    color: var(--tcn-text);
+}
+
+.tcn-platform-section-description,
+.tcn-platform-section-header .description {
+    margin: 0;
+    color: var(--tcn-text-muted);
+    font-size: 14px;
+}
+
+.tcn-platform-section .form-table {
+    margin-top: 0;
+}
+
+.tcn-platform-section .form-table th {
+    width: 240px;
+    padding-top: 16px;
+    padding-bottom: 16px;
+    color: var(--tcn-text);
+}
+
+.tcn-platform-section .form-table td {
+    padding-top: 16px;
+    padding-bottom: 16px;
+}
+
+.tcn-platform-section .form-table input[type="text"],
+.tcn-platform-section .form-table input[type="url"],
+.tcn-platform-section .form-table input[type="number"],
+.tcn-platform-section .form-table input[type="password"],
+.tcn-platform-section .form-table select,
+.tcn-platform-section .form-table textarea {
+    width: min(100%, 380px);
+    padding: 10px 12px;
+    border-radius: 8px;
+    border: 1px solid var(--tcn-border);
+    box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.05);
+}
+
+.tcn-platform-section .description {
+    margin-top: 8px;
+    font-size: 13px;
+    color: var(--tcn-text-muted);
+}
+
+.tcn-platform-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 32px;
+}
+
+.tcn-platform-actions .button-primary,
+.tcn-platform-actions .button.button-primary {
+    padding: 12px 26px;
+    font-size: 15px;
+    border-radius: 999px;
+    background: linear-gradient(120deg, var(--tcn-primary) 0%, var(--tcn-primary-dark) 100%);
+    box-shadow: 0 12px 24px rgba(37, 99, 235, 0.35);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tcn-platform-actions .button-primary:hover,
+.tcn-platform-actions .button.button-primary:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 16px 32px rgba(29, 78, 216, 0.35);
+}
+
+.tcn-level-field {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    margin-right: 16px;
+    border-radius: 999px;
+    background: var(--tcn-surface-muted);
+    border: 1px solid rgba(148, 163, 184, 0.45);
+}
+
+.tcn-level-field input.small-text {
+    width: 100px;
+    padding: 6px 10px;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    background: #ffffff;
+    box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.tcn-level-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 12px;
+    border-radius: 12px;
+    background: rgba(37, 99, 235, 0.12);
+    color: var(--tcn-primary-dark);
+    font-weight: 600;
+}
+
+.tcn-platform-levels {
+    padding: 0;
+    border: none;
+    box-shadow: none;
+    background: transparent;
 }
 
 .tcn-platform-levels table {
     width: 100%;
-    border-collapse: collapse;
+    border-collapse: separate;
+    border-spacing: 0;
+    overflow: hidden;
+    border-radius: var(--tcn-radius-md);
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+}
+
+.tcn-platform-levels thead {
+    background: linear-gradient(120deg, rgba(37, 99, 235, 0.95), rgba(59, 130, 246, 0.85));
+    color: #ffffff;
 }
 
 .tcn-platform-levels th,
 .tcn-platform-levels td {
-    border: 1px solid #e2e8f0;
-    padding: 10px;
-    text-align: left;
+    padding: 16px 20px;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.2);
 }
 
 .tcn-platform-levels tbody tr:nth-child(even) {
-    background-color: #f8fafc;
+    background: rgba(241, 245, 249, 0.8);
 }
 
-.tcn-platform-settings .form-table th {
-    width: 220px;
+.tcn-platform-levels tbody tr:last-child td {
+    border-bottom: none;
 }
 
-.tcn-platform-notice {
-    border-left: 4px solid #2271b1;
-    padding: 12px;
-    background: #f0f6fc;
+.tcn-platform-levels small {
+    color: var(--tcn-text-muted);
 }
 
-.tcn-platform-logs .description {
-    margin-bottom: 1rem;
+.tcn-platform-api-tester .tcn-platform-panel,
+.tcn-platform-logs .tcn-platform-panel,
+.tcn-platform-settings .tcn-platform-panel {
+    margin-bottom: 28px;
+    padding: 24px 28px;
+    border-radius: var(--tcn-radius-md);
+    background: var(--tcn-surface);
+    border: 1px solid var(--tcn-border);
+    box-shadow: 0 12px 26px rgba(15, 23, 42, 0.08);
+}
+
+.tcn-platform-api-form {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.tcn-platform-api-grid {
+    display: grid;
+    gap: 20px;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.tcn-platform-api-field {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.tcn-platform-api-field textarea,
+.tcn-platform-api-field select,
+.tcn-platform-api-field input[type="text"],
+.tcn-platform-api-field input[type="number"] {
+    padding: 12px 14px;
+    border-radius: 10px;
+    border: 1px solid var(--tcn-border);
+    box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.05);
+    font-size: 14px;
+}
+
+.tcn-platform-api-label {
+    font-weight: 600;
+    color: var(--tcn-text);
+}
+
+.tcn-platform-api-form .description {
+    margin-top: -6px;
+}
+
+.tcn-platform-api-form .button-primary {
+    padding: 10px 24px;
+    border-radius: 999px;
+    background: linear-gradient(120deg, var(--tcn-primary) 0%, var(--tcn-primary-dark) 100%);
+    box-shadow: 0 12px 24px rgba(37, 99, 235, 0.28);
+}
+
+.tcn-platform-api-form .tcn-platform-api-reset.button {
+    border-radius: 999px;
+    padding: 10px 24px;
+}
+
+.tcn-platform-api-response {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.tcn-platform-api-response h2 {
+    margin: 0;
+}
+
+.tcn-platform-api-meta {
+    display: grid;
+    gap: 12px;
+    padding: 18px 20px;
+    border-radius: var(--tcn-radius-md);
+    background: var(--tcn-surface-muted);
+    border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.tcn-platform-api-meta-label {
+    display: block;
+    font-size: 12px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--tcn-text-muted);
+    margin-bottom: 4px;
+}
+
+.tcn-platform-api-meta-value,
+.tcn-platform-api-status {
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.tcn-platform-api-status {
+    display: inline-flex;
+    gap: 8px;
+    align-items: baseline;
+    color: var(--tcn-primary-dark);
+}
+
+.tcn-platform-api-details {
+    padding: 16px 18px;
+    border-radius: 12px;
+    border: 1px solid var(--tcn-border);
+    background: #ffffff;
+}
+
+.tcn-platform-api-details summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--tcn-text);
+}
+
+.tcn-platform-api-details-grid {
+    display: grid;
+    gap: 18px;
+    margin-top: 14px;
+}
+
+.tcn-platform-api-details pre,
+.tcn-platform-api-response pre,
+.tcn-platform-api-example pre,
+.tcn-platform-log-pre {
+    padding: 16px;
+    margin: 12px 0 0;
+    border-radius: 12px;
+    background: #0f172a;
+    color: #e2e8f0;
+    font-size: 13px;
+    line-height: 1.55;
+    overflow-x: auto;
+}
+
+.tcn-platform-api-examples {
+    display: flex;
+    flex-direction: column;
+    gap: 22px;
+}
+
+.tcn-platform-api-examples-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 20px;
+}
+
+.tcn-platform-api-example {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 20px 22px;
+    border-radius: var(--tcn-radius-md);
+    background: var(--tcn-surface-muted);
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    box-shadow: 0 10px 20px rgba(15, 23, 42, 0.08);
+}
+
+.tcn-platform-api-example-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.tcn-platform-api-method {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 56px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    font-weight: 700;
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    background: rgba(37, 99, 235, 0.18);
+    color: var(--tcn-primary-dark);
+}
+
+.tcn-platform-api-path {
+    font-weight: 600;
+    color: var(--tcn-text);
+}
+
+.tcn-platform-api-example .description {
+    font-size: 13px;
+}
+
+.tcn-platform-api-example details {
+    margin-top: 6px;
+}
+
+.tcn-platform-api-example details summary {
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.tcn-platform-logs .tcn-platform-panel + .tcn-platform-panel {
+    margin-top: 0;
 }
 
 .tcn-platform-log-actions {
-    margin: 1rem 0;
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 18px;
+}
+
+.tcn-platform-log-actions .button {
+    border-radius: 999px;
+    padding: 9px 20px;
+}
+
+.tcn-platform-log-table-wrapper {
+    border-radius: var(--tcn-radius-md);
+    border: 1px solid var(--tcn-border);
+    overflow: hidden;
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
 }
 
 .tcn-platform-log-table td,
@@ -132,12 +545,8 @@
 }
 
 .tcn-platform-log-pre {
-    background: #f6f7f7;
-    border-radius: 4px;
-    padding: 8px 10px;
-    margin: 0;
-    white-space: pre-wrap;
-    word-break: break-word;
+    background: #0f172a;
+    color: #e2e8f0;
 }
 
 .tcn-platform-log-boolean.is-true {
@@ -158,367 +567,69 @@
     font-size: 12px;
     font-weight: 600;
     text-transform: uppercase;
-    letter-spacing: 0.02em;
-    background: #e2e8f0;
-    color: #1f2937;
+    letter-spacing: 0.08em;
+    background: rgba(15, 118, 110, 0.12);
+    color: #0f766e;
 }
 
-.tcn-platform-log-badge.is-success {
-    background: #dcfce7;
-    color: #065f46;
+.tcn-platform-log-table.dataTable tbody tr {
+    background-color: #ffffff;
 }
 
-.tcn-platform-log-badge.is-error {
-    background: #fee2e2;
-    color: #b91c1c;
-}
-
-.tcn-platform-log-badge.is-warning {
-    background: #fef3c7;
-    color: #b45309;
-}
-
-.tcn-platform-log-badge.is-muted {
-    background: #e0e7ff;
-    color: #4338ca;
-}
-
-.tcn-platform-log-number,
-.tcn-platform-log-text {
-    font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
-}
-
-.tcn-platform-log-empty {
-    color: #64748b;
-    font-style: italic;
-}
-
-.tcn-platform-log-table-wrapper {
-    margin-top: 1.5rem;
-    overflow-x: auto;
-}
-
-.tcn-platform-api-tester {
-    max-width: 960px;
-}
-
-.tcn-platform-api-tester h1 {
-    margin-bottom: 1rem;
-}
-
-.tcn-platform-api-form {
-    margin-top: 1.5rem;
-    margin-bottom: 2rem;
-    background: #fff;
-    border: 1px solid #ccd0d4;
-    border-radius: 8px;
-    padding: 24px;
-    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
-}
-
-.tcn-platform-api-grid {
-    display: grid;
-    grid-template-columns: minmax(120px, 160px) minmax(0, 1fr);
-    gap: 16px;
-    margin-bottom: 20px;
-}
-
-.tcn-platform-api-field {
-    margin-bottom: 20px;
-}
-
-.tcn-platform-api-field.is-wide {
-    grid-column: span 2;
-}
-
-.tcn-platform-api-label {
-    display: block;
-    font-weight: 600;
-    margin-bottom: 6px;
-}
-
-.tcn-platform-api-form select,
-.tcn-platform-api-form input[type="text"],
-.tcn-platform-api-form textarea {
-    width: 100%;
-}
-
-.tcn-platform-api-form textarea {
-    font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
-    font-size: 13px;
-}
-
-.tcn-platform-api-response {
-    background: #fff;
-    border: 1px solid #ccd0d4;
-    border-radius: 8px;
-    padding: 24px;
-    margin-bottom: 2rem;
-    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
-}
-
-.tcn-platform-api-meta {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    gap: 12px 24px;
-    margin-bottom: 1.5rem;
-}
-
-.tcn-platform-api-meta-label {
-    display: block;
-    font-size: 12px;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: #64748b;
-    margin-bottom: 4px;
-}
-
-.tcn-platform-api-meta-value {
-    font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
-    word-break: break-word;
-}
-
-.tcn-platform-api-status {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    font-weight: 600;
-    padding: 4px 10px;
-    border-radius: 999px;
-    background: #f1f5f9;
-    color: #0f172a;
-}
-
-.tcn-platform-api-status small {
-    font-size: 12px;
-    font-weight: 500;
-}
-
-.tcn-platform-api-details {
-    margin-top: 1rem;
-}
-
-.tcn-platform-api-details summary {
-    cursor: pointer;
-    font-weight: 600;
-    margin-bottom: 0.5rem;
-}
-
-.tcn-platform-api-details pre {
-    background: #f6f7f7;
-    border-radius: 6px;
-    padding: 12px;
-    margin: 0;
-    overflow-x: auto;
-}
-
-.tcn-platform-api-details-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    gap: 16px;
-}
-
-.tcn-platform-api-examples {
-    background: #fff;
-    border: 1px solid #ccd0d4;
-    border-radius: 8px;
-    padding: 24px;
-    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
-}
-
-.tcn-platform-api-examples-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    gap: 20px;
-    margin-top: 1.5rem;
-}
-
-.tcn-platform-api-example {
-    border: 1px solid #e2e8f0;
-    border-radius: 8px;
-    padding: 16px;
-    background: #f8fafc;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-}
-
-.tcn-platform-api-example-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 8px;
-}
-
-.tcn-platform-api-method {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 2px 10px;
-    border-radius: 999px;
-    font-size: 12px;
-    font-weight: 700;
-    letter-spacing: 0.05em;
-    background: #e2e8f0;
-    color: #0f172a;
-}
-
-.tcn-platform-api-method-post {
-    background: #dbeafe;
-    color: #1d4ed8;
-}
-
-.tcn-platform-api-method-get {
-    background: #dcfce7;
-    color: #047857;
-}
-
-.tcn-platform-api-method-delete {
-    background: #fee2e2;
-    color: #b91c1c;
-}
-
-.tcn-platform-api-method-put,
-.tcn-platform-api-method-patch {
-    background: #ede9fe;
-    color: #6d28d9;
-}
-
-.tcn-platform-api-path {
-    font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
-    font-size: 12px;
-    background: #fff;
-    border-radius: 4px;
-    padding: 2px 6px;
-    color: #0f172a;
-}
-
-.tcn-platform-api-example details pre {
-    max-height: 220px;
-}
-
-.tcn-platform-api-example .description {
-    color: #475569;
-    margin: 0;
-}
-
-.tcn-platform-api-example button.button {
-    align-self: flex-start;
-}
-
-@media (max-width: 782px) {
-    .tcn-platform-api-grid {
-        grid-template-columns: 1fr;
-    }
-
-    .tcn-platform-api-field.is-wide {
-        grid-column: auto;
-    }
-}
-
-.tcn-platform-log-table.dataTable {
-    width: 100% !important;
-}
-
-.tcn-platform-log-table thead th.tcn-platform-log-col-time,
-.tcn-platform-log-table tbody td.tcn-platform-log-col-time {
-    width: 140px;
-}
-
-.tcn-platform-log-table thead th.tcn-platform-log-col-source,
-.tcn-platform-log-table tbody td.tcn-platform-log-col-source {
-    width: 130px;
-}
-
-.tcn-platform-log-table thead th.tcn-platform-log-col-message,
-.tcn-platform-log-table tbody td.tcn-platform-log-col-message {
-    width: 240px;
-}
-
-.tcn-platform-log-table thead th.tcn-platform-log-col-details,
-.tcn-platform-log-table tbody td.tcn-platform-log-col-details {
-    min-width: 260px;
+.tcn-platform-log-table.dataTable tbody tr:nth-child(even) {
+    background-color: #f8fafc;
 }
 
 .tcn-platform-log-controls,
 .tcn-platform-log-footer {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 12px;
-    align-items: center;
-    justify-content: space-between;
-    margin: 0 0 12px;
+    padding: 12px 18px;
 }
 
-.tcn-platform-log-footer {
-    margin-top: 16px;
+.tcn-platform-log-controls .dataTables_filter input,
+.tcn-platform-log-controls .dataTables_length select {
+    border-radius: 999px;
+    padding: 6px 14px;
+    border: 1px solid var(--tcn-border);
 }
 
-.dataTables_wrapper .dataTables_filter label {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin: 0;
-}
-
-.dataTables_wrapper .dataTables_filter input {
-    border-radius: 4px;
-    border: 1px solid #ccd0d4;
-    padding: 4px 10px;
-    min-width: 220px;
-    background: #fff;
-    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.04);
-}
-
-.dataTables_wrapper .dataTables_length select {
-    border-radius: 4px;
-    border: 1px solid #ccd0d4;
-    padding: 2px 6px;
-    background: #fff;
-}
-
-.dataTables_wrapper .dataTables_paginate {
-    margin: 0;
-}
-
-.dataTables_wrapper .dataTables_paginate .paginate_button {
-    border-radius: 4px !important;
-    border: 1px solid transparent !important;
-    padding: 4px 10px !important;
-    margin: 0 2px !important;
-    color: #1d2327 !important;
-}
-
-.dataTables_wrapper .dataTables_paginate .paginate_button:hover {
-    background: #f0f6fc !important;
-    border-color: #c3daf3 !important;
-}
-
-.dataTables_wrapper .dataTables_paginate .paginate_button.current,
-.dataTables_wrapper .dataTables_paginate .paginate_button.current:hover {
-    background: #2271b1 !important;
-    color: #fff !important;
-    border-color: #1c5c92 !important;
-}
-
-@media screen and (max-width: 782px) {
-    .tcn-platform-log-controls,
-    .tcn-platform-log-footer {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 16px;
+@media (max-width: 960px) {
+    .wrap.tcn-platform-settings,
+    .wrap.tcn-platform-api-tester,
+    .wrap.tcn-platform-logs {
+        padding: 24px 24px 36px;
     }
 
-    .dataTables_wrapper .dataTables_filter label {
-        width: 100%;
+    .tcn-platform-section {
+        padding: 20px;
+    }
+}
+
+@media (max-width: 782px) {
+    .tcn-platform-section .form-table th {
+        width: auto;
     }
 
-    .dataTables_wrapper .dataTables_filter input {
-        width: 100%;
-        min-width: 0;
+    .tcn-platform-section .form-table td,
+    .tcn-platform-section .form-table th {
+        padding-top: 12px;
+        padding-bottom: 12px;
     }
 
-    .dataTables_wrapper .dataTables_length select {
+    .tcn-platform-actions {
+        justify-content: stretch;
+    }
+
+    .tcn-platform-actions .button-primary,
+    .tcn-platform-actions .button.button-primary {
         width: 100%;
+        text-align: center;
+    }
+
+    .tcn-platform-card-grid {
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    .tcn-platform-api-grid {
+        grid-template-columns: 1fr;
     }
 }

--- a/includes/Admin/ApiTesterPage.php
+++ b/includes/Admin/ApiTesterPage.php
@@ -142,10 +142,12 @@ class ApiTesterPage {
 
         ?>
         <div class="wrap tcn-platform-api-tester">
-            <h1><?php esc_html_e( 'TCN Platform API Tester', 'tcnapp-connector' ); ?></h1>
-            <p class="description">
-                <?php esc_html_e( 'Send requests to the plugin\'s REST endpoints without leaving the WordPress dashboard. Use the form below to craft a request, then review the response details.', 'tcnapp-connector' ); ?>
-            </p>
+            <div class="tcn-platform-page-intro">
+                <h1><?php esc_html_e( 'TCN Platform API Tester', 'tcnapp-connector' ); ?></h1>
+                <p class="description tcn-platform-page-subtitle">
+                    <?php esc_html_e( 'Send requests to the plugin\'s REST endpoints without leaving the WordPress dashboard. Use the form below to craft a request, then review the response details.', 'tcnapp-connector' ); ?>
+                </p>
+            </div>
 
             <?php if ( ! empty( $errors ) ) : ?>
                 <div class="notice notice-error">
@@ -157,7 +159,7 @@ class ApiTesterPage {
                 </div>
             <?php endif; ?>
 
-            <form method="post" class="tcn-platform-api-form">
+            <form method="post" class="tcn-platform-api-form tcn-platform-panel">
                 <?php wp_nonce_field( 'tcn_platform_api_tester', 'tcn_platform_api_tester_nonce' ); ?>
 
                 <div class="tcn-platform-api-grid">
@@ -195,7 +197,7 @@ class ApiTesterPage {
             </form>
 
             <?php if ( null !== $response && empty( $errors ) ) : ?>
-                <div class="tcn-platform-api-response">
+                <div class="tcn-platform-panel tcn-platform-api-response">
                     <h2><?php esc_html_e( 'Response', 'tcnapp-connector' ); ?></h2>
                     <?php if ( $response instanceof WP_Error ) : ?>
                         <div class="notice notice-error">
@@ -267,7 +269,7 @@ class ApiTesterPage {
                 </div>
             <?php endif; ?>
 
-            <div class="tcn-platform-api-examples">
+            <div class="tcn-platform-panel tcn-platform-api-examples">
                 <h2><?php esc_html_e( 'Example requests', 'tcnapp-connector' ); ?></h2>
                 <p class="description"><?php esc_html_e( 'Use these ready-made examples to explore key endpoints. Click “Load in tester” to populate the form above.', 'tcnapp-connector' ); ?></p>
                 <div class="tcn-platform-api-examples-grid">

--- a/includes/Admin/LogPage.php
+++ b/includes/Admin/LogPage.php
@@ -90,10 +90,12 @@ class LogPage {
         $logs = Logger::get_logs();
         ?>
         <div class="wrap tcn-platform-logs">
-            <h1><?php esc_html_e( 'TCN Platform Activity Log', 'tcnapp-connector' ); ?></h1>
-            <p class="description">
-                <?php esc_html_e( 'Review REST API calls from the TCNApp mobile client and key plugin actions. The most recent 200 entries are stored.', 'tcnapp-connector' ); ?>
-            </p>
+            <div class="tcn-platform-page-intro">
+                <h1><?php esc_html_e( 'TCN Platform Activity Log', 'tcnapp-connector' ); ?></h1>
+                <p class="description tcn-platform-page-subtitle">
+                    <?php esc_html_e( 'Review REST API calls from the TCNApp mobile client and key plugin actions. The most recent 200 entries are stored.', 'tcnapp-connector' ); ?>
+                </p>
+            </div>
 
             <?php if ( isset( $_GET['tcn_log_cleared'] ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended ?>
                 <div class="notice notice-success is-dismissible">
@@ -101,40 +103,42 @@ class LogPage {
                 </div>
             <?php endif; ?>
 
-            <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="tcn-platform-log-actions">
-                <?php wp_nonce_field( 'tcn_platform_clear_logs', 'tcn_platform_clear_logs_nonce' ); ?>
-                <input type="hidden" name="action" value="tcn_platform_clear_logs" />
-                <?php submit_button( __( 'Clear Log', 'tcnapp-connector' ), 'delete', 'submit', false ); ?>
-            </form>
+            <div class="tcn-platform-panel">
+                <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="tcn-platform-log-actions">
+                    <?php wp_nonce_field( 'tcn_platform_clear_logs', 'tcn_platform_clear_logs_nonce' ); ?>
+                    <input type="hidden" name="action" value="tcn_platform_clear_logs" />
+                    <?php submit_button( __( 'Clear Log', 'tcnapp-connector' ), 'delete', 'submit', false ); ?>
+                </form>
 
-            <div class="tcn-platform-log-table-wrapper">
-                <table id="tcn-platform-log-table" class="widefat fixed striped tcn-platform-log-table display nowrap" style="width:100%">
-                    <thead>
-                        <tr>
-                            <th><?php esc_html_e( 'Time', 'tcnapp-connector' ); ?></th>
-                            <th><?php esc_html_e( 'Source', 'tcnapp-connector' ); ?></th>
-                            <th><?php esc_html_e( 'Message', 'tcnapp-connector' ); ?></th>
-                            <th><?php esc_html_e( 'Details', 'tcnapp-connector' ); ?></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <?php if ( empty( $logs ) ) : ?>
+                <div class="tcn-platform-log-table-wrapper">
+                    <table id="tcn-platform-log-table" class="widefat fixed striped tcn-platform-log-table display nowrap" style="width:100%">
+                        <thead>
                             <tr>
-                                <td colspan="4"><?php esc_html_e( 'No activity recorded yet.', 'tcnapp-connector' ); ?></td>
+                                <th><?php esc_html_e( 'Time', 'tcnapp-connector' ); ?></th>
+                                <th><?php esc_html_e( 'Source', 'tcnapp-connector' ); ?></th>
+                                <th><?php esc_html_e( 'Message', 'tcnapp-connector' ); ?></th>
+                                <th><?php esc_html_e( 'Details', 'tcnapp-connector' ); ?></th>
                             </tr>
-                        <?php else : ?>
-                            <?php foreach ( $logs as $entry ) : ?>
-                                <?php $timestamp = isset( $entry['time'] ) ? (int) $entry['time'] : 0; ?>
+                        </thead>
+                        <tbody>
+                            <?php if ( empty( $logs ) ) : ?>
                                 <tr>
-                                    <td data-order="<?php echo esc_attr( $timestamp ); ?>"><?php echo esc_html( $this->format_time( $timestamp ) ); ?></td>
-                                    <td><?php echo esc_html( $this->format_source( $entry['source'] ) ); ?></td>
-                                    <td><?php echo esc_html( $entry['message'] ); ?></td>
-                                    <td><?php echo $this->render_details( $entry['context'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
+                                    <td colspan="4"><?php esc_html_e( 'No activity recorded yet.', 'tcnapp-connector' ); ?></td>
                                 </tr>
-                            <?php endforeach; ?>
-                        <?php endif; ?>
-                    </tbody>
-                </table>
+                            <?php else : ?>
+                                <?php foreach ( $logs as $entry ) : ?>
+                                    <?php $timestamp = isset( $entry['time'] ) ? (int) $entry['time'] : 0; ?>
+                                    <tr>
+                                        <td data-order="<?php echo esc_attr( $timestamp ); ?>"><?php echo esc_html( $this->format_time( $timestamp ) ); ?></td>
+                                        <td><?php echo esc_html( $this->format_source( $entry['source'] ) ); ?></td>
+                                        <td><?php echo esc_html( $entry['message'] ); ?></td>
+                                        <td><?php echo $this->render_details( $entry['context'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
+                                    </tr>
+                                <?php endforeach; ?>
+                            <?php endif; ?>
+                        </tbody>
+                    </table>
+                </div>
             </div>
         </div>
         <?php

--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -122,9 +122,12 @@ class SettingsPage {
         settings_errors( 'tcn_platform' );
         ?>
         <div class="wrap tcn-platform-settings">
-            <h1><?php esc_html_e( 'TCN Platform', 'tcnapp-connector' ); ?></h1>
+            <div class="tcn-platform-page-intro">
+                <h1><?php esc_html_e( 'TCN Platform', 'tcnapp-connector' ); ?></h1>
+                <p class="description tcn-platform-page-subtitle"><?php esc_html_e( 'Tune the platform modules, membership tiers, and integrations powering the TCN mobile experience.', 'tcnapp-connector' ); ?></p>
+            </div>
 
-            <form method="post">
+            <form method="post" class="tcn-platform-panel">
                 <?php wp_nonce_field( 'tcn_platform_settings', 'tcn_platform_settings_nonce' ); ?>
 
                 <div class="tcn-platform-card-grid">
@@ -143,61 +146,69 @@ class SettingsPage {
                     </div>
                 </div>
 
-                <h2><?php esc_html_e( 'Password Login API Settings', 'tcnapp-connector' ); ?></h2>
-                <table class="form-table" role="presentation">
-                    <tbody>
-                        <tr>
-                            <th scope="row">
-                                <label for="allowed_origin"><?php esc_html_e( 'Allowed CORS Origin', 'tcnapp-connector' ); ?></label>
-                            </th>
-                            <td>
-                                <input type="url" id="allowed_origin" name="allowed_origin" class="regular-text" value="<?php echo esc_attr( $login_settings['allowed_origin'] ); ?>" placeholder="https://app.example.com" />
-                                <p class="description"><?php esc_html_e( 'Leave blank to restrict requests to the WordPress origin.', 'tcnapp-connector' ); ?></p>
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label for="allow_dev_http"><?php esc_html_e( 'Allow HTTP During Development', 'tcnapp-connector' ); ?></label>
-                            </th>
-                            <td>
-                                <label>
-                                    <input type="checkbox" id="allow_dev_http" name="allow_dev_http" value="1" <?php checked( ! empty( $login_settings['allow_dev_http'] ) ); ?> />
-                                    <?php esc_html_e( 'Permit non-HTTPS requests when WP_DEBUG is enabled.', 'tcnapp-connector' ); ?>
-                                </label>
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label for="token_lifetime"><?php esc_html_e( 'Login Token Lifetime (seconds)', 'tcnapp-connector' ); ?></label>
-                            </th>
-                            <td>
-                                <input type="number" min="60" step="60" id="token_lifetime" name="token_lifetime" value="<?php echo esc_attr( $login_settings['token_lifetime'] ); ?>" />
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label for="rate_limit"><?php esc_html_e( 'Rate Limit Attempts', 'tcnapp-connector' ); ?></label>
-                            </th>
-                            <td>
-                                <input type="number" min="3" id="rate_limit" name="rate_limit" value="<?php echo esc_attr( $login_settings['rate_limit'] ); ?>" />
-                                <p class="description"><?php esc_html_e( 'Maximum attempts allowed per window per user/IP before temporarily blocking requests.', 'tcnapp-connector' ); ?></p>
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label for="rate_limit_window"><?php esc_html_e( 'Rate Limit Window (seconds)', 'tcnapp-connector' ); ?></label>
-                            </th>
-                            <td>
-                                <input type="number" min="60" step="60" id="rate_limit_window" name="rate_limit_window" value="<?php echo esc_attr( $login_settings['rate_limit_window'] ); ?>" />
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
+                <section class="tcn-platform-section">
+                    <div class="tcn-platform-section-header">
+                        <h2><?php esc_html_e( 'Password Login API Settings', 'tcnapp-connector' ); ?></h2>
+                        <p class="tcn-platform-section-description"><?php esc_html_e( 'Configure authentication behaviour for the Password Login API module.', 'tcnapp-connector' ); ?></p>
+                    </div>
+                    <table class="form-table" role="presentation">
+                        <tbody>
+                            <tr>
+                                <th scope="row">
+                                    <label for="allowed_origin"><?php esc_html_e( 'Allowed CORS Origin', 'tcnapp-connector' ); ?></label>
+                                </th>
+                                <td>
+                                    <input type="url" id="allowed_origin" name="allowed_origin" class="regular-text" value="<?php echo esc_attr( $login_settings['allowed_origin'] ); ?>" placeholder="https://app.example.com" />
+                                    <p class="description"><?php esc_html_e( 'Leave blank to restrict requests to the WordPress origin.', 'tcnapp-connector' ); ?></p>
+                                </td>
+                            </tr>
+                            <tr>
+                                <th scope="row">
+                                    <label for="allow_dev_http"><?php esc_html_e( 'Allow HTTP During Development', 'tcnapp-connector' ); ?></label>
+                                </th>
+                                <td>
+                                    <label>
+                                        <input type="checkbox" id="allow_dev_http" name="allow_dev_http" value="1" <?php checked( ! empty( $login_settings['allow_dev_http'] ) ); ?> />
+                                        <?php esc_html_e( 'Permit non-HTTPS requests when WP_DEBUG is enabled.', 'tcnapp-connector' ); ?>
+                                    </label>
+                                </td>
+                            </tr>
+                            <tr>
+                                <th scope="row">
+                                    <label for="token_lifetime"><?php esc_html_e( 'Login Token Lifetime (seconds)', 'tcnapp-connector' ); ?></label>
+                                </th>
+                                <td>
+                                    <input type="number" min="60" step="60" id="token_lifetime" name="token_lifetime" value="<?php echo esc_attr( $login_settings['token_lifetime'] ); ?>" />
+                                </td>
+                            </tr>
+                            <tr>
+                                <th scope="row">
+                                    <label for="rate_limit"><?php esc_html_e( 'Rate Limit Attempts', 'tcnapp-connector' ); ?></label>
+                                </th>
+                                <td>
+                                    <input type="number" min="3" id="rate_limit" name="rate_limit" value="<?php echo esc_attr( $login_settings['rate_limit'] ); ?>" />
+                                    <p class="description"><?php esc_html_e( 'Maximum attempts allowed per window per user/IP before temporarily blocking requests.', 'tcnapp-connector' ); ?></p>
+                                </td>
+                            </tr>
+                            <tr>
+                                <th scope="row">
+                                    <label for="rate_limit_window"><?php esc_html_e( 'Rate Limit Window (seconds)', 'tcnapp-connector' ); ?></label>
+                                </th>
+                                <td>
+                                    <input type="number" min="60" step="60" id="rate_limit_window" name="rate_limit_window" value="<?php echo esc_attr( $login_settings['rate_limit_window'] ); ?>" />
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </section>
 
-                <h2><?php esc_html_e( 'Mobile Payments', 'tcnapp-connector' ); ?></h2>
-                <p class="description"><?php esc_html_e( 'Provide your Stripe API keys so the mobile app can create payment intents during membership upgrades.', 'tcnapp-connector' ); ?></p>
-                <table class="form-table" role="presentation">
-                    <tbody>
+                <section class="tcn-platform-section">
+                    <div class="tcn-platform-section-header">
+                        <h2><?php esc_html_e( 'Mobile Payments', 'tcnapp-connector' ); ?></h2>
+                        <p class="description tcn-platform-section-description"><?php esc_html_e( 'Provide your Stripe API keys so the mobile app can create payment intents during membership upgrades.', 'tcnapp-connector' ); ?></p>
+                    </div>
+                    <table class="form-table" role="presentation">
+                        <tbody>
                         <tr>
                             <th scope="row">
                                 <label for="stripe_publishable_key"><?php esc_html_e( 'Stripe Publishable Key', 'tcnapp-connector' ); ?></label>
@@ -217,97 +228,111 @@ class SettingsPage {
                         </tr>
                     </tbody>
                 </table>
+                </section>
 
-                <h2><?php esc_html_e( 'Membership Products', 'tcnapp-connector' ); ?></h2>
-                <p class="description"><?php esc_html_e( 'Select the WooCommerce products that correspond to each membership plan. These mappings ensure upgrades keep working even if product titles or slugs change.', 'tcnapp-connector' ); ?></p>
-                <table class="form-table" role="presentation">
-                    <tbody>
-                        <?php if ( empty( $product_options ) && ! function_exists( 'wc_get_products' ) ) : ?>
-                            <tr>
-                                <th scope="row"><?php esc_html_e( 'Membership Products', 'tcnapp-connector' ); ?></th>
-                                <td>
-                                    <p class="description"><?php esc_html_e( 'Install and activate WooCommerce to assign products to membership levels.', 'tcnapp-connector' ); ?></p>
-                                </td>
-                            </tr>
-                        <?php else : ?>
+                <section class="tcn-platform-section">
+                    <div class="tcn-platform-section-header">
+                        <h2><?php esc_html_e( 'Membership Products', 'tcnapp-connector' ); ?></h2>
+                        <p class="description tcn-platform-section-description"><?php esc_html_e( 'Select the WooCommerce products that correspond to each membership plan. These mappings ensure upgrades keep working even if product titles or slugs change.', 'tcnapp-connector' ); ?></p>
+                    </div>
+                    <table class="form-table" role="presentation">
+                        <tbody>
+                            <?php if ( empty( $product_options ) && ! function_exists( 'wc_get_products' ) ) : ?>
+                                <tr>
+                                    <th scope="row"><?php esc_html_e( 'Membership Products', 'tcnapp-connector' ); ?></th>
+                                    <td>
+                                        <p class="description"><?php esc_html_e( 'Install and activate WooCommerce to assign products to membership levels.', 'tcnapp-connector' ); ?></p>
+                                    </td>
+                                </tr>
+                            <?php else : ?>
+                                <?php foreach ( $levels as $level ) :
+                                    if ( empty( $level['slug'] ) ) {
+                                        continue;
+                                    }
+
+                                    $slug      = sanitize_key( (string) $level['slug'] );
+                                    $selected  = isset( $product_map[ $slug ] ) ? (int) $product_map[ $slug ] : 0;
+                                    $label     = isset( $level['name'] ) ? (string) $level['name'] : $slug;
+                                    $options   = $product_options;
+
+                                    if ( $selected > 0 && ! isset( $options[ $selected ] ) ) {
+                                        /* translators: %d: WooCommerce product ID */
+                                        $options[ $selected ] = sprintf( __( 'Product #%d (not found)', 'tcnapp-connector' ), $selected );
+                                    }
+                                    ?>
+                                    <tr>
+                                        <th scope="row">
+                                            <label for="membership_products_<?php echo esc_attr( $slug ); ?>"><?php echo esc_html( $label ); ?></label>
+                                        </th>
+                                        <td>
+                                            <?php if ( empty( $options ) ) : ?>
+                                                <p class="description"><?php esc_html_e( 'Create WooCommerce products to enable membership mapping.', 'tcnapp-connector' ); ?></p>
+                                            <?php else : ?>
+                                                <select id="membership_products_<?php echo esc_attr( $slug ); ?>" name="membership_products[<?php echo esc_attr( $slug ); ?>]">
+                                                    <?php foreach ( $options as $product_id => $product_label ) : ?>
+                                                        <option value="<?php echo esc_attr( $product_id ); ?>" <?php selected( $selected, $product_id ); ?>><?php echo esc_html( $product_label ); ?></option>
+                                                    <?php endforeach; ?>
+                                                </select>
+                                            <?php endif; ?>
+                                        </td>
+                                    </tr>
+                                <?php endforeach; ?>
+                            <?php endif; ?>
+                        </tbody>
+                    </table>
+                </section>
+
+                <section class="tcn-platform-section">
+                    <div class="tcn-platform-section-header">
+                        <h2><?php esc_html_e( 'Membership Commissions', 'tcnapp-connector' ); ?></h2>
+                        <p class="description tcn-platform-section-description"><?php esc_html_e( 'Adjust the direct and passive commission amounts for each tier. These settings drive the payouts recorded when members recruit their network.', 'tcnapp-connector' ); ?></p>
+                    </div>
+                    <table class="form-table" role="presentation">
+                        <tbody>
                             <?php foreach ( $levels as $level ) :
                                 if ( empty( $level['slug'] ) ) {
                                     continue;
                                 }
 
-                                $slug      = sanitize_key( (string) $level['slug'] );
-                                $selected  = isset( $product_map[ $slug ] ) ? (int) $product_map[ $slug ] : 0;
-                                $label     = isset( $level['name'] ) ? (string) $level['name'] : $slug;
-                                $options   = $product_options;
-
-                                if ( $selected > 0 && ! isset( $options[ $selected ] ) ) {
-                                    /* translators: %d: WooCommerce product ID */
-                                    $options[ $selected ] = sprintf( __( 'Product #%d (not found)', 'tcnapp-connector' ), $selected );
-                                }
-                                ?>
-                                <tr>
-                                    <th scope="row">
-                                        <label for="membership_products_<?php echo esc_attr( $slug ); ?>"><?php echo esc_html( $label ); ?></label>
-                                    </th>
-                                    <td>
-                                        <?php if ( empty( $options ) ) : ?>
-                                            <p class="description"><?php esc_html_e( 'Create WooCommerce products to enable membership mapping.', 'tcnapp-connector' ); ?></p>
-                                        <?php else : ?>
-                                            <select id="membership_products_<?php echo esc_attr( $slug ); ?>" name="membership_products[<?php echo esc_attr( $slug ); ?>]">
-                                                <?php foreach ( $options as $product_id => $product_label ) : ?>
-                                                    <option value="<?php echo esc_attr( $product_id ); ?>" <?php selected( $selected, $product_id ); ?>><?php echo esc_html( $product_label ); ?></option>
-                                                <?php endforeach; ?>
-                                            </select>
-                                        <?php endif; ?>
-                                    </td>
-                                </tr>
+                                $slug        = sanitize_key( (string) $level['slug'] );
+                                $level_name  = isset( $level['name'] ) ? (string) $level['name'] : $slug;
+                                $direct_id   = 'membership_levels_' . $slug . '_direct';
+                                $passive_id  = 'membership_levels_' . $slug . '_passive';
+                                $direct_val  = isset( $level['commission_direct'] ) ? (float) $level['commission_direct'] : 0.0;
+                                $passive_val = isset( $level['commission_passive'] ) ? (float) $level['commission_passive'] : 0.0;
+                            ?>
+                            <tr>
+                                <th scope="row">
+                                    <span class="tcn-level-label"><?php echo esc_html( $level_name ); ?></span>
+                                </th>
+                                <td>
+                                    <fieldset>
+                                        <label for="<?php echo esc_attr( $direct_id ); ?>" class="tcn-level-field">
+                                            <?php esc_html_e( 'Direct commission', 'tcnapp-connector' ); ?>
+                                            <input type="number" min="0" step="0.01" id="<?php echo esc_attr( $direct_id ); ?>" name="membership_levels[<?php echo esc_attr( $slug ); ?>][commission_direct]" value="<?php echo esc_attr( $direct_val ); ?>" class="small-text" />
+                                        </label>
+                                        <label for="<?php echo esc_attr( $passive_id ); ?>" class="tcn-level-field">
+                                            <?php esc_html_e( 'Passive commission', 'tcnapp-connector' ); ?>
+                                            <input type="number" min="0" step="0.01" id="<?php echo esc_attr( $passive_id ); ?>" name="membership_levels[<?php echo esc_attr( $slug ); ?>][commission_passive]" value="<?php echo esc_attr( $passive_val ); ?>" class="small-text" />
+                                        </label>
+                                    </fieldset>
+                                </td>
+                            </tr>
                             <?php endforeach; ?>
-                        <?php endif; ?>
-                    </tbody>
-                </table>
+                        </tbody>
+                    </table>
+                </section>
 
-                <h2><?php esc_html_e( 'Membership Commissions', 'tcnapp-connector' ); ?></h2>
-                <p class="description"><?php esc_html_e( 'Adjust the direct and passive commission amounts for each tier. These settings drive the payouts recorded when members recruit their network.', 'tcnapp-connector' ); ?></p>
-                <table class="form-table" role="presentation">
-                    <tbody>
-                        <?php foreach ( $levels as $level ) :
-                            if ( empty( $level['slug'] ) ) {
-                                continue;
-                            }
-
-                            $slug        = sanitize_key( (string) $level['slug'] );
-                            $level_name  = isset( $level['name'] ) ? (string) $level['name'] : $slug;
-                            $direct_id   = 'membership_levels_' . $slug . '_direct';
-                            $passive_id  = 'membership_levels_' . $slug . '_passive';
-                            $direct_val  = isset( $level['commission_direct'] ) ? (float) $level['commission_direct'] : 0.0;
-                            $passive_val = isset( $level['commission_passive'] ) ? (float) $level['commission_passive'] : 0.0;
-                        ?>
-                        <tr>
-                            <th scope="row">
-                                <span class="tcn-level-label"><?php echo esc_html( $level_name ); ?></span>
-                            </th>
-                            <td>
-                                <fieldset>
-                                    <label for="<?php echo esc_attr( $direct_id ); ?>" class="tcn-level-field">
-                                        <?php esc_html_e( 'Direct commission', 'tcnapp-connector' ); ?>
-                                        <input type="number" min="0" step="0.01" id="<?php echo esc_attr( $direct_id ); ?>" name="membership_levels[<?php echo esc_attr( $slug ); ?>][commission_direct]" value="<?php echo esc_attr( $direct_val ); ?>" class="small-text" />
-                                    </label>
-                                    <label for="<?php echo esc_attr( $passive_id ); ?>" class="tcn-level-field">
-                                        <?php esc_html_e( 'Passive commission', 'tcnapp-connector' ); ?>
-                                        <input type="number" min="0" step="0.01" id="<?php echo esc_attr( $passive_id ); ?>" name="membership_levels[<?php echo esc_attr( $slug ); ?>][commission_passive]" value="<?php echo esc_attr( $passive_val ); ?>" class="small-text" />
-                                    </label>
-                                </fieldset>
-                            </td>
-                        </tr>
-                        <?php endforeach; ?>
-                    </tbody>
-                </table>
-
-                <?php submit_button(); ?>
+                <div class="tcn-platform-actions">
+                    <?php submit_button( __( 'Save settings', 'tcnapp-connector' ), 'primary large tcn-platform-button', 'submit', false ); ?>
+                </div>
             </form>
 
-            <div class="tcn-platform-card tcn-platform-levels">
-                <h2><?php esc_html_e( 'Membership Levels', 'tcnapp-connector' ); ?></h2>
+            <div class="tcn-platform-section tcn-platform-levels">
+                <div class="tcn-platform-section-header">
+                    <h2><?php esc_html_e( 'Membership Levels', 'tcnapp-connector' ); ?></h2>
+                    <p class="tcn-platform-section-description"><?php esc_html_e( 'Review the fees and commissions powering each tier at a glance.', 'tcnapp-connector' ); ?></p>
+                </div>
                 <table>
                     <thead>
                         <tr>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.35
+Stable tag: 0.3.36
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -61,6 +61,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.36 =
+* Enhancement: Polish the admin experience with cohesive cards, panels, and typography refinements across settings, the API tester, and the activity log.
+
 = 0.3.35 =
 * Fix: Fall back to a direct WordPress product query when WooCommerce's product helper returns nothing so the membership mapping dropdown still lists existing catalogue items.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.35
+ * Version:           0.3.36
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.35' );
+define( 'TCN_PLATFORM_VERSION', '0.3.36' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- restyle the admin settings, API tester, and activity log screens with new panels, card layouts, and typography refinements
- reorganize settings markup to match the updated styling and surface clearer section descriptions
- bump the plugin version to 0.3.36 and document the UI refresh in the readme files

## Testing
- php -l includes/Admin/SettingsPage.php
- php -l includes/Admin/ApiTesterPage.php
- php -l includes/Admin/LogPage.php
- php -l tcnapp-connector.php

------
https://chatgpt.com/codex/tasks/task_e_68e19285247483279fd44241851e6da8