### PR TITLE
Add profile avatar upload REST endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,12 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.38
+- Add a `/gn/v1/profile/avatar` REST endpoint that uploads profile photos to the Media Library, stores avatar metadata, and returns the refreshed `/wp/v2/users/me` payload used by the mobile app.
+- Extend the docs and API tester presets so administrators can review the multipart upload requirements, headers, and sample responses for the avatar route.
+
 ### 0.3.37
-- Sync the WordPress.org `readme.txt` with the detailed project README so plugin documentation stays consistent across distribut
-ion channels.
+- Sync the WordPress.org `readme.txt` with the detailed project README so plugin documentation stays consistent across distribution channels.
 
 ### 0.3.36
 - Polish every admin screen with elevated cards, section panels, and richer typography so settings, logs, and the API tester feel cohesive and easier to scan.

--- a/docs/TCN_PLATFORM_REFERENCE.md
+++ b/docs/TCN_PLATFORM_REFERENCE.md
@@ -29,6 +29,7 @@ Every endpoint listed below has a matching preset in the tester, so you can vali
 | `/forgot-password` | POST | None | Start a password reset, optionally returning a short-lived verification code. |
 | `/reset-password` | POST | None | Complete a reset via verification code or WordPress key. |
 | `/change-password` | POST | Logged-in user (cookie or `X-WP-Nonce`) | Change the current user password after verifying the existing password. |
+| `/profile/avatar` | POST | Logged-in user (cookie or Bearer token) | Upload a profile photo and return the refreshed `/wp-json/wp/v2/users/me` payload. |
 
 **Key request parameters**
 
@@ -41,6 +42,41 @@ Every endpoint listed below has a matching preset in the tester, so you can vali
 
 - Success payloads contain `success: true`, along with contextual data such as `token`, `redirect`, and `user` profile arrays.
 - Errors return `WP_Error` objects with HTTP status codes (400, 401, 403, 404, 409, 429) depending on validation failures or rate limiting.
+
+#### WordPress Avatar Upload Endpoint
+
+The mobile app now calls `POST /wp-json/gn/v1/profile/avatar` to upload a member's profile photo. The endpoint is expected to accept a `multipart/form-data` payload with an `avatar` field that contains the uploaded image file. A successful response must return the updated user profile in the same shape as `/wp-json/wp/v2/users/me` so the client can refresh the cached session.
+
+##### Minimum requirements
+
+1. **Authentication** – The route must require a logged-in user and support both cookie- and token-based authentication (Bearer token).
+2. **Image handling** – Save the uploaded file to the WordPress Media Library. Store the attachment ID (or resulting URL) in user meta so the avatar appears in `avatar_urls` when requesting the user profile.
+3. **Response body** – Return a JSON object containing the updated user information, e.g.
+
+   ```json
+   {
+     "id": 123,
+     "email": "member@example.com",
+     "name": "Member Example",
+     "first_name": "Member",
+     "last_name": "Example",
+     "avatar_urls": {
+       "48": "https://example.com/avatar-48x48.jpg",
+       "96": "https://example.com/avatar-96x96.jpg"
+     }
+   }
+   ```
+
+4. **Error handling** – Reply with meaningful error codes (`400`, `401`, `415`, etc.) and messages so the app can surface problems to the user.
+
+##### Suggested implementation
+
+- Register a custom REST route in a plugin (e.g. **TCN Platform**) that hooks into `rest_api_init`.
+- Use `wp_handle_upload` to process the uploaded image and `wp_update_user` or `update_user_meta` to attach the media item as the user's avatar (plugins such as Simple Local Avatars or WP User Avatar can help manage this meta).
+- Return the updated user data by reusing the callback that powers `/wp-json/wp/v2/users/me` to guarantee the response format matches what the app expects.
+- Ensure the route respects WordPress capability checks (e.g. `current_user_can( 'upload_files' )`).
+
+With this endpoint in place the mobile app will automatically update WordPress whenever a member changes their photo.
 
 ### 2.2 Membership & MLM (`/wp-json/tcn-mlm/v1` and `/wp-json/gn/v1/memberships/*`)
 

--- a/includes/Admin/ApiTesterPage.php
+++ b/includes/Admin/ApiTesterPage.php
@@ -374,6 +374,7 @@ class ApiTesterPage {
         $forgot_url       = home_url( '/wp-json/gn/v1/forgot-password' );
         $reset_url        = home_url( '/wp-json/gn/v1/reset-password' );
         $change_url       = home_url( '/wp-json/gn/v1/change-password' );
+        $avatar_url       = home_url( '/wp-json/gn/v1/profile/avatar' );
         $plans_url        = home_url( '/wp-json/gn/v1/memberships/plans' );
         $stripe_intent    = home_url( '/wp-json/gn/v1/memberships/stripe-intent' );
         $confirm_upgrade  = home_url( '/wp-json/gn/v1/memberships/confirm' );
@@ -496,6 +497,38 @@ class ApiTesterPage {
                 'response'    => wp_json_encode(
                     array(
                         'success' => true,
+                    ),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                ) ?: '',
+            ),
+            array(
+                'method'      => 'POST',
+                'url'         => $avatar_url,
+                'description' => __( 'Upload a profile photo and refresh the user session payload.', 'tcnapp-connector' ),
+                'note'        => __( 'Requires Authorization: Bearer token or authenticated cookies plus multipart/form-data with an avatar file.', 'tcnapp-connector' ),
+                'headers'     => wp_json_encode(
+                    array(
+                        'Authorization' => 'Bearer paste-login-token',
+                        'Content-Type'  => 'multipart/form-data',
+                    ),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                ) ?: '',
+                'body'        => sprintf(
+                    /* translators: %s: Example REST endpoint URL. */
+                    __( "This endpoint expects multipart/form-data. Example curl command:\n\ncurl -X POST \\\n  -H \"Authorization: Bearer paste-login-token\" \\\n  -F \"avatar=@/path/to/avatar.jpg\" \\\n  \"%s\"", 'tcnapp-connector' ),
+                    $avatar_url
+                ),
+                'response'    => wp_json_encode(
+                    array(
+                        'id'          => 123,
+                        'email'       => 'member@example.com',
+                        'name'        => 'Member Example',
+                        'first_name'  => 'Member',
+                        'last_name'   => 'Example',
+                        'avatar_urls' => array(
+                            '48' => 'https://example.com/avatar-48x48.jpg',
+                            '96' => 'https://example.com/avatar-96x96.jpg',
+                        ),
                     ),
                     JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
                 ) ?: '',

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -7,6 +7,7 @@ use TCN\Platform\Admin\LogPage;
 use TCN\Platform\Admin\SettingsPage;
 use TCN\Platform\Auth\PasswordLoginService;
 use TCN\Platform\Membership\MembershipModule;
+use TCN\Platform\Rest\ProfileEndpoints;
 use TCN\Platform\Rest\WooCommerceEndpoints;
 use TCN\Platform\Support\Modules;
 use TCN\Platform\Support\ActivityMonitor;
@@ -58,6 +59,8 @@ class Plugin {
         if ( function_exists( 'wc_get_customer_id_by_email' ) ) {
             $this->services[] = new WooCommerceEndpoints();
         }
+
+        $this->services[] = new ProfileEndpoints();
 
         if ( is_admin() ) {
             $this->services[] = new SettingsPage( $this->modules );

--- a/includes/Rest/ProfileEndpoints.php
+++ b/includes/Rest/ProfileEndpoints.php
@@ -1,0 +1,352 @@
+<?php
+namespace TCN\Platform\Rest;
+
+use TCN\Platform\Auth\PasswordLoginService;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+class ProfileEndpoints {
+    /**
+     * Register WordPress hooks.
+     */
+    public function register(): void {
+        add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+        add_filter( 'rest_prepare_user', array( $this, 'filter_user_response' ), 20, 3 );
+    }
+
+    /**
+     * Register the avatar upload endpoint.
+     */
+    public function register_routes(): void {
+        register_rest_route(
+            'gn/v1',
+            '/profile/avatar',
+            array(
+                array(
+                    'methods'             => WP_REST_Server::CREATABLE,
+                    'callback'            => array( $this, 'handle_avatar_upload' ),
+                    'permission_callback' => array( $this, 'permissions_check' ),
+                    'args'                => array(),
+                ),
+            )
+        );
+    }
+
+    /**
+     * Ensure the requester is authenticated and can upload files.
+     */
+    public function permissions_check( WP_REST_Request $request ) {
+        $user_id = get_current_user_id();
+
+        if ( $user_id <= 0 ) {
+            $user_id = $this->authenticate_with_bearer_token( $request );
+        }
+
+        if ( $user_id <= 0 ) {
+            return new WP_Error(
+                'tcn_rest_unauthorized',
+                __( 'Authentication is required to upload an avatar.', 'tcnapp-connector' ),
+                array( 'status' => rest_authorization_required_code() )
+            );
+        }
+
+        $request->set_attribute( 'tcn_authenticated_user_id', $user_id );
+
+        if ( ! current_user_can( 'upload_files' ) ) {
+            return new WP_Error(
+                'tcn_rest_forbidden',
+                __( 'You do not have permission to upload files.', 'tcnapp-connector' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        return true;
+    }
+
+    /**
+     * Handle the avatar upload and return the updated user payload.
+     */
+    public function handle_avatar_upload( WP_REST_Request $request ) {
+        $user_id = (int) $request->get_attribute( 'tcn_authenticated_user_id' );
+
+        if ( $user_id <= 0 ) {
+            $user_id = get_current_user_id();
+        }
+
+        if ( $user_id <= 0 ) {
+            return new WP_Error(
+                'tcn_rest_unauthorized',
+                __( 'Authentication is required to upload an avatar.', 'tcnapp-connector' ),
+                array( 'status' => rest_authorization_required_code() )
+            );
+        }
+
+        if ( empty( $_FILES['avatar'] ) ) {
+            return new WP_Error(
+                'tcn_avatar_missing',
+                __( 'Upload an image file using the avatar field.', 'tcnapp-connector' ),
+                array( 'status' => 400 )
+            );
+        }
+
+        $file = $_FILES['avatar'];
+
+        if ( ! isset( $file['tmp_name'] ) || '' === $file['tmp_name'] ) {
+            return new WP_Error(
+                'tcn_avatar_missing',
+                __( 'Upload an image file using the avatar field.', 'tcnapp-connector' ),
+                array( 'status' => 400 )
+            );
+        }
+
+        if ( ! empty( $file['error'] ) && UPLOAD_ERR_OK !== (int) $file['error'] ) {
+            return new WP_Error(
+                'tcn_avatar_upload_error',
+                $this->describe_upload_error( (int) $file['error'] ),
+                array( 'status' => 400 )
+            );
+        }
+
+        require_once ABSPATH . 'wp-admin/includes/file.php';
+        require_once ABSPATH . 'wp-admin/includes/image.php';
+        require_once ABSPATH . 'wp-admin/includes/post.php';
+
+        $upload = wp_handle_upload(
+            $file,
+            array(
+                'test_form' => false,
+            )
+        );
+
+        if ( isset( $upload['error'] ) ) {
+            return new WP_Error(
+                'tcn_avatar_upload_error',
+                $upload['error'],
+                array( 'status' => $this->determine_upload_error_status( $upload['error'] ) )
+            );
+        }
+
+        $file_path = isset( $upload['file'] ) ? (string) $upload['file'] : '';
+        $file_type = isset( $upload['type'] ) ? (string) $upload['type'] : '';
+
+        if ( empty( $file_path ) ) {
+            return new WP_Error(
+                'tcn_avatar_upload_error',
+                __( 'Unable to process the uploaded file.', 'tcnapp-connector' ),
+                array( 'status' => 500 )
+            );
+        }
+
+        if ( empty( $file_type ) || 0 !== strpos( $file_type, 'image/' ) ) {
+            wp_delete_file( $file_path );
+
+            return new WP_Error(
+                'tcn_avatar_invalid_type',
+                __( 'The uploaded file must be a valid image.', 'tcnapp-connector' ),
+                array( 'status' => 415 )
+            );
+        }
+
+        $attachment = array(
+            'post_mime_type' => $file_type,
+            'post_title'     => sanitize_file_name( wp_basename( $file_path ) ),
+            'post_content'   => '',
+            'post_status'    => 'inherit',
+            'post_author'    => $user_id,
+        );
+
+        $attachment_id = wp_insert_attachment( $attachment, $file_path );
+
+        if ( is_wp_error( $attachment_id ) || ! $attachment_id ) {
+            wp_delete_file( $file_path );
+
+            return new WP_Error(
+                'tcn_avatar_store_failed',
+                __( 'Unable to save the avatar to the Media Library.', 'tcnapp-connector' ),
+                array( 'status' => 500 )
+            );
+        }
+
+        $metadata = wp_generate_attachment_metadata( $attachment_id, $file_path );
+        if ( ! empty( $metadata ) ) {
+            wp_update_attachment_metadata( $attachment_id, $metadata );
+        }
+
+        $avatar_urls = $this->prepare_avatar_urls( $attachment_id );
+
+        update_user_meta( $user_id, '_gn_profile_avatar_id', $attachment_id );
+        update_user_meta( $user_id, '_gn_profile_avatar_urls', $avatar_urls );
+        update_user_meta(
+            $user_id,
+            'simple_local_avatar',
+            array(
+                'full'     => isset( $avatar_urls['full'] ) ? $avatar_urls['full'] : wp_get_attachment_url( $attachment_id ),
+                'media_id' => $attachment_id,
+            )
+        );
+
+        clean_user_cache( $user_id );
+
+        $user_response = $this->prepare_user_response( $request );
+        if ( is_wp_error( $user_response ) ) {
+            return $user_response;
+        }
+
+        return $user_response;
+    }
+
+    /**
+     * Inject stored avatar URLs into REST user responses.
+     */
+    public function filter_user_response( $response, $user, $request ) {
+        if ( ! $response instanceof WP_REST_Response ) {
+            return $response;
+        }
+
+        $avatar_id = (int) get_user_meta( $user->ID, '_gn_profile_avatar_id', true );
+        if ( $avatar_id <= 0 ) {
+            return $response;
+        }
+
+        $avatar_urls = $this->prepare_avatar_urls( $avatar_id );
+        if ( empty( $avatar_urls ) ) {
+            return $response;
+        }
+
+        $data = $response->get_data();
+        $data['avatar_urls'] = array_merge( isset( $data['avatar_urls'] ) && is_array( $data['avatar_urls'] ) ? $data['avatar_urls'] : array(), $avatar_urls );
+        $response->set_data( $data );
+
+        return $response;
+    }
+
+    /**
+     * Attempt to authenticate using a Password Login API bearer token.
+     */
+    protected function authenticate_with_bearer_token( WP_REST_Request $request ): int {
+        $header = $request->get_header( 'authorization' );
+
+        if ( empty( $header ) && isset( $_SERVER['HTTP_AUTHORIZATION'] ) ) {
+            $header = (string) wp_unslash( $_SERVER['HTTP_AUTHORIZATION'] );
+        }
+
+        if ( ! is_string( $header ) || '' === $header ) {
+            return 0;
+        }
+
+        if ( ! preg_match( '/Bearer\s+(.*)$/i', $header, $matches ) ) {
+            return 0;
+        }
+
+        $token = trim( (string) $matches[1] );
+        if ( '' === $token ) {
+            return 0;
+        }
+
+        if ( ! class_exists( PasswordLoginService::class ) ) {
+            return 0;
+        }
+
+        $payload = get_transient( PasswordLoginService::TOKEN_PREFIX . md5( $token ) );
+        if ( ! is_array( $payload ) || empty( $payload['user_id'] ) ) {
+            return 0;
+        }
+
+        $user_id = (int) $payload['user_id'];
+        if ( $user_id <= 0 || ! get_user_by( 'id', $user_id ) ) {
+            return 0;
+        }
+
+        wp_set_current_user( $user_id );
+
+        return $user_id;
+    }
+
+    /**
+     * Prepare avatar URLs for the response payload.
+     */
+    protected function prepare_avatar_urls( int $attachment_id ): array {
+        $urls  = array();
+        $sizes = array( 24, 48, 96, 192, 256 );
+
+        foreach ( $sizes as $size ) {
+            $image = wp_get_attachment_image_src( $attachment_id, array( $size, $size ) );
+            if ( is_array( $image ) && ! empty( $image[0] ) ) {
+                $urls[ (string) $size ] = $image[0];
+            }
+        }
+
+        $full = wp_get_attachment_url( $attachment_id );
+        if ( $full ) {
+            $urls['full'] = $full;
+        }
+
+        return $urls;
+    }
+
+    /**
+     * Return a REST-ready user response for the authenticated user.
+     */
+    protected function prepare_user_response( WP_REST_Request $request ) {
+        $sub_request = new WP_REST_Request( 'GET', '/wp/v2/users/me' );
+        $context     = $request->get_param( 'context' );
+
+        if ( $context ) {
+            $sub_request->set_param( 'context', $context );
+        }
+
+        $response = rest_do_request( $sub_request );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        if ( $response instanceof WP_REST_Response ) {
+            return rest_ensure_response( $response->get_data() );
+        }
+
+        return rest_ensure_response( $response );
+    }
+
+    /**
+     * Provide friendly error messages for common upload failures.
+     */
+    protected function describe_upload_error( int $code ): string {
+        switch ( $code ) {
+            case UPLOAD_ERR_INI_SIZE:
+            case UPLOAD_ERR_FORM_SIZE:
+                return __( 'The uploaded file exceeds the maximum allowed size.', 'tcnapp-connector' );
+            case UPLOAD_ERR_PARTIAL:
+                return __( 'The file was only partially uploaded. Please try again.', 'tcnapp-connector' );
+            case UPLOAD_ERR_NO_FILE:
+                return __( 'No file was uploaded. Choose an image to continue.', 'tcnapp-connector' );
+            case UPLOAD_ERR_NO_TMP_DIR:
+                return __( 'Missing a temporary folder on the server.', 'tcnapp-connector' );
+            case UPLOAD_ERR_CANT_WRITE:
+                return __( 'Failed to write the file to disk.', 'tcnapp-connector' );
+            case UPLOAD_ERR_EXTENSION:
+                return __( 'A PHP extension stopped the file upload.', 'tcnapp-connector' );
+            default:
+                return __( 'An unexpected error occurred while uploading the file.', 'tcnapp-connector' );
+        }
+    }
+
+    /**
+     * Map wp_handle_upload errors to HTTP status codes.
+     */
+    protected function determine_upload_error_status( string $message ): int {
+        $message = strtolower( $message );
+
+        if ( false !== strpos( $message, 'type' ) || false !== strpos( $message, 'mime' ) ) {
+            return 415;
+        }
+
+        if ( false !== strpos( $message, 'size' ) ) {
+            return 413;
+        }
+
+        return 400;
+    }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.37
+Stable tag: 0.3.38
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -93,6 +93,10 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.38 =
+* Feature: Add a `/gn/v1/profile/avatar` REST endpoint that stores uploaded profile photos in the Media Library, updates avatar metadata, and returns the refreshed `/wp/v2/users/me` payload for the mobile app.
+* Enhancement: Document the avatar upload workflow and surface an API tester preset so administrators can review the required headers, payload, and response format.
+
 = 0.3.37 =
 * Maintenance: Sync `readme.txt` with the project README and bump the plugin version for distribution.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.37
+ * Version:           0.3.38
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.37' );
+define( 'TCN_PLATFORM_VERSION', '0.3.38' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- add a new `gn/v1/profile/avatar` REST route that authenticates via cookies or Password Login API tokens and stores uploaded images in the Media Library while updating user avatar metadata
- inject custom avatar URLs into REST user payloads and return the refreshed `/wp/v2/users/me` response from the upload endpoint
- document the avatar workflow, bump the plugin version to 0.3.38, and expose an API tester preset for the new route

## Testing
- `php -l includes/Rest/ProfileEndpoints.php`


------
https://chatgpt.com/codex/tasks/task_e_68e23f2ef3548327a6b8899f6575b324