### PR TITLE
Expand Activity Log layout width

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.39
+- Expand the Activity Log canvas so the DataTable, payload badges, and context panels have room to display wide REST parameters without forcing horizontal scrolling.
+
 ### 0.3.38
 - Add a `/gn/v1/profile/avatar` REST endpoint that uploads profile photos to the Media Library, stores avatar metadata, and returns the refreshed `/wp/v2/users/me` payload used by the mobile app.
 - Extend the docs and API tester presets so administrators can review the multipart upload requirements, headers, and sample responses for the avatar route.

--- a/admin/css/tcn-platform-admin.css
+++ b/admin/css/tcn-platform-admin.css
@@ -18,12 +18,17 @@
 .wrap.tcn-platform-api-tester,
 .wrap.tcn-platform-logs {
     position: relative;
+    width: 100%;
     max-width: 1080px;
     padding: 32px 36px 44px;
     margin-top: 26px;
     border-radius: calc(var(--tcn-radius-lg) + 6px);
     background: linear-gradient(160deg, #eef2ff 0%, #f8fafc 30%, #ffffff 100%);
     box-shadow: var(--tcn-shadow-soft);
+}
+
+.wrap.tcn-platform-logs {
+    max-width: 1480px;
 }
 
 .wrap.tcn-platform-settings::before,

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.38
+Stable tag: 0.3.39
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -93,6 +93,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.39 =
+* Enhancement: Stretch the Activity Log layout so administrators can review wider payloads, context details, and table columns without constant horizontal scrolling.
+
 = 0.3.38 =
 * Feature: Add a `/gn/v1/profile/avatar` REST endpoint that stores uploaded profile photos in the Media Library, updates avatar metadata, and returns the refreshed `/wp/v2/users/me` payload for the mobile app.
 * Enhancement: Document the avatar upload workflow and surface an API tester preset so administrators can review the required headers, payload, and response format.

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.38
+ * Version:           0.3.39
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.38' );
+define( 'TCN_PLATFORM_VERSION', '0.3.39' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- widen the Activity Log admin wrapper so its DataTable and context panels can display wider payloads
- bump the plugin version to 0.3.39 and document the release notes for distribution

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e243aa90d083279ed6781c2fe9a074