### PR TITLE
Expose WooCommerce credentials in login responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.40
+- Surface the `WOOCOMMERCE_CONSUMER_KEY`/`WOOCOMMERCE_CONSUMER_SECRET` bundle in Password Login API responses so authenticated clients can automatically sign WooCommerce bridge requests.
+
 ### 0.3.39
 - Expand the Activity Log canvas so the DataTable, payload badges, and context panels have room to display wide REST parameters without forcing horizontal scrolling.
 

--- a/docs/TCN_PLATFORM_REFERENCE.md
+++ b/docs/TCN_PLATFORM_REFERENCE.md
@@ -42,6 +42,7 @@ Every endpoint listed below has a matching preset in the tester, so you can vali
 
 - Success payloads contain `success: true`, along with contextual data such as `token`, `redirect`, and `user` profile arrays.
 - Errors return `WP_Error` objects with HTTP status codes (400, 401, 403, 404, 409, 429) depending on validation failures or rate limiting.
+- When `WOOCOMMERCE_CONSUMER_KEY` and `WOOCOMMERCE_CONSUMER_SECRET` constants are defined, successful responses include an `auth.woocommerce` bundle (plus the same data on the `user.woocommerce` key) exposing the consumer pair and ready-to-use Basic authorization header for subsequent bridge requests.
 
 #### WordPress Avatar Upload Endpoint
 
@@ -215,7 +216,8 @@ The tables below enumerate every method, its visibility, parameters, return valu
 | `handle_change_password( WP_REST_Request $request )` | public | Validates current password, sets new password, refreshes auth cookies, fires `gn_password_api_password_changed`. | `$request` | array or `WP_Error` | — |
 | `filter_pre_serve_request( $served, $result, $request, $server )` | public | Adds CORS headers for `gn/v1` namespace. | Mixed | bool | Called during REST response serving. |
 | `handle_token_login()` | public | Consumes transient token, logs user in, redirects (filterable). | — | void | Halts execution with `wp_safe_redirect()`. |
-| `prepare_user_payload( WP_User $user )` | protected | Builds REST payload with membership metadata. | `$user` | array | Includes sponsor ID. |
+| `prepare_user_payload( WP_User $user )` | protected | Builds REST payload with membership metadata. | `$user` | array | Includes sponsor ID and WooCommerce credentials when available. |
+| `get_woocommerce_credentials()` | protected | Returns constants-backed WooCommerce consumer credentials plus Basic header helper. | — | array | Empty when constants missing/blank. |
 | `get_user_from_login( string $login )` | protected | Resolves login/email to `WP_User`. | `$login` | `WP_User|null` | Returns null when not found. |
 | `maybe_enforce_https( WP_REST_Request $request )` | protected | Blocks non-HTTPS requests unless dev override filter allows. | `$request` | true or `WP_Error` | Uses login settings and `gn_password_api_allow_dev_http` filter. |
 | `build_rate_context( string $action, string $identifier )` | protected | Generates transient key, limit, TTL for rate limiting. | `$action`, `$identifier` | array | Combines action, username, IP. |

--- a/includes/Auth/PasswordLoginService.php
+++ b/includes/Auth/PasswordLoginService.php
@@ -114,31 +114,36 @@ class PasswordLoginService {
 
         $this->reset_rate_limit( $rate_context );
 
+        $response = array(
+            'success' => true,
+            'user'    => $this->prepare_user_payload( $user ),
+        );
+
         if ( 'cookie' === $mode ) {
             wp_set_current_user( $user->ID );
             wp_set_auth_cookie( $user->ID, true );
+        } else {
+            $token = $this->issue_login_token( $user->ID );
 
-            return array(
-                'success' => true,
-                'user'    => $this->prepare_user_payload( $user ),
-            );
-        }
-
-        $token = $this->issue_login_token( $user->ID );
-
-        return array(
-            'success'     => true,
-            'token'       => $token['token'],
-            'expires_in'  => $token['expires_in'],
-            'redirect'    => add_query_arg(
+            $response['token']      = $token['token'];
+            $response['expires_in'] = $token['expires_in'];
+            $response['redirect']   = add_query_arg(
                 array(
                     'action' => 'gn_token_login',
                     'token'  => rawurlencode( $token['token'] ),
                 ),
                 wp_login_url()
-            ),
-            'user'        => $this->prepare_user_payload( $user ),
-        );
+            );
+        }
+
+        $woocommerce_credentials = $this->get_woocommerce_credentials();
+        if ( ! empty( $woocommerce_credentials ) ) {
+            $response['auth'] = array(
+                'woocommerce' => $woocommerce_credentials,
+            );
+        }
+
+        return $response;
     }
 
     public function handle_register( WP_REST_Request $request ) {
@@ -351,7 +356,7 @@ class PasswordLoginService {
     }
 
     protected function prepare_user_payload( WP_User $user ): array {
-        return array(
+        $payload = array(
             'id'               => $user->ID,
             'username'         => $user->user_login,
             'email'            => $user->user_email,
@@ -360,6 +365,35 @@ class PasswordLoginService {
             'last_name'        => $user->last_name,
             'membership_level' => get_user_meta( $user->ID, '_tcn_membership_level', true ),
             'sponsor_id'       => (int) get_user_meta( $user->ID, '_tcn_sponsor_id', true ),
+        );
+
+        $woocommerce_credentials = $this->get_woocommerce_credentials();
+        if ( ! empty( $woocommerce_credentials ) ) {
+            $payload['woocommerce'] = $woocommerce_credentials;
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Retrieve WooCommerce REST API credentials exposed via constants.
+     */
+    protected function get_woocommerce_credentials(): array {
+        if ( ! defined( 'WOOCOMMERCE_CONSUMER_KEY' ) || ! defined( 'WOOCOMMERCE_CONSUMER_SECRET' ) ) {
+            return array();
+        }
+
+        $key    = trim( (string) WOOCOMMERCE_CONSUMER_KEY );
+        $secret = trim( (string) WOOCOMMERCE_CONSUMER_SECRET );
+
+        if ( '' === $key || '' === $secret ) {
+            return array();
+        }
+
+        return array(
+            'consumer_key'    => $key,
+            'consumer_secret' => $secret,
+            'authorization'   => 'Basic ' . base64_encode( $key . ':' . $secret ),
         );
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.39
+Stable tag: 0.3.40
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -93,6 +93,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.40 =
+* Enhancement: Include the `WOOCOMMERCE_CONSUMER_KEY` and `WOOCOMMERCE_CONSUMER_SECRET` values in Password Login API responses so authenticated clients can automatically sign WooCommerce REST requests.
+
 = 0.3.39 =
 * Enhancement: Stretch the Activity Log layout so administrators can review wider payloads, context details, and table columns without constant horizontal scrolling.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.39
+ * Version:           0.3.40
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.39' );
+define( 'TCN_PLATFORM_VERSION', '0.3.40' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- return WooCommerce consumer key/secret details with Password Login API responses and user payloads when constants are defined
- document the new auth bundle in the platform reference, README, and readme.txt while bumping the plugin version to 0.3.40

## Testing
- php -l includes/Auth/PasswordLoginService.php
- php -l tcnapp-connector.php

------
https://chatgpt.com/codex/tasks/task_e_68e247829f48832792f490efaa0e23e7