### PR TITLE
Reuse Password Login bearer tokens across REST modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.41
+- Centralise Password Login bearer token validation and reuse it across profile, membership, and password-change REST endpoints so mobile clients can authenticate with either tokens or session cookies.
+- Return REST-friendly `WP_Error` responses when tokens are invalid or expired to keep API feedback consistent.
+
 ### 0.3.40
 - Surface the `WOOCOMMERCE_CONSUMER_KEY`/`WOOCOMMERCE_CONSUMER_SECRET` bundle in Password Login API responses so authenticated clients can automatically sign WooCommerce bridge requests.
 

--- a/includes/Auth/PasswordLoginService.php
+++ b/includes/Auth/PasswordLoginService.php
@@ -1,6 +1,7 @@
 <?php
 namespace TCN\Platform\Auth;
 
+use TCN\Platform\Auth\TokenAuthenticator;
 use TCN\Platform\Support\Options;
 use WP_Error;
 use WP_REST_Request;
@@ -15,6 +16,15 @@ class PasswordLoginService {
      * @var array<string, mixed>
      */
     protected $settings = array();
+
+    /**
+     * @var TokenAuthenticator|null
+     */
+    protected $token_authenticator;
+
+    public function __construct( ?TokenAuthenticator $token_authenticator = null ) {
+        $this->token_authenticator = $token_authenticator;
+    }
 
     public function register(): void {
         $this->settings = Options::get_login_settings();
@@ -79,9 +89,7 @@ class PasswordLoginService {
             array(
                 'methods'             => 'POST',
                 'callback'            => array( $this, 'handle_change_password' ),
-                'permission_callback' => function () {
-                    return is_user_logged_in();
-                },
+                'permission_callback' => array( $this, 'require_login_or_token' ),
             )
         );
     }
@@ -281,6 +289,11 @@ class PasswordLoginService {
             return $https;
         }
 
+        $authenticated = $this->authenticate_with_token( $request );
+        if ( is_wp_error( $authenticated ) ) {
+            return $authenticated;
+        }
+
         $user = wp_get_current_user();
         if ( ! $user || ! $user->ID ) {
             return new WP_Error( 'gn_not_authenticated', __( 'Authentication required.', 'tcnapp-connector' ), array( 'status' => 401 ) );
@@ -304,6 +317,31 @@ class PasswordLoginService {
         do_action( 'gn_password_api_password_changed', $user->ID, $request );
 
         return array( 'success' => true );
+    }
+
+    public function require_login_or_token( WP_REST_Request $request ) {
+        $authenticated = $this->authenticate_with_token( $request );
+        if ( is_wp_error( $authenticated ) ) {
+            return $authenticated;
+        }
+
+        if ( $authenticated > 0 || is_user_logged_in() ) {
+            return true;
+        }
+
+        return new WP_Error(
+            'gn_not_authenticated',
+            __( 'Authentication required.', 'tcnapp-connector' ),
+            array( 'status' => rest_authorization_required_code() )
+        );
+    }
+
+    protected function authenticate_with_token( WP_REST_Request $request ) {
+        if ( ! $this->token_authenticator ) {
+            return 0;
+        }
+
+        return $this->token_authenticator->authenticate_request( $request );
     }
 
     public function filter_pre_serve_request( $served, $result, $request, $server ) {

--- a/includes/Auth/TokenAuthenticator.php
+++ b/includes/Auth/TokenAuthenticator.php
@@ -1,0 +1,71 @@
+<?php
+namespace TCN\Platform\Auth;
+
+use WP_Error;
+use WP_REST_Request;
+
+class TokenAuthenticator {
+    /**
+     * Attempt to authenticate a REST request using the password login bearer token.
+     *
+     * @return int|WP_Error Returns the authenticated user ID on success, 0 when no token is present, or WP_Error for invalid tokens.
+     */
+    public function authenticate_request( WP_REST_Request $request ) {
+        $header = $request->get_header( 'authorization' );
+
+        if ( empty( $header ) && isset( $_SERVER['HTTP_AUTHORIZATION'] ) ) {
+            $header = (string) wp_unslash( $_SERVER['HTTP_AUTHORIZATION'] );
+        }
+
+        if ( ! is_string( $header ) || '' === trim( $header ) ) {
+            return 0;
+        }
+
+        if ( ! preg_match( '/Bearer\s+(.*)$/i', $header, $matches ) ) {
+            return new WP_Error(
+                'tcn_rest_invalid_token',
+                __( 'The provided authentication token is invalid.', 'tcnapp-connector' ),
+                array( 'status' => rest_authorization_required_code() )
+            );
+        }
+
+        $token = trim( (string) $matches[1] );
+        if ( '' === $token ) {
+            return new WP_Error(
+                'tcn_rest_invalid_token',
+                __( 'The provided authentication token is invalid.', 'tcnapp-connector' ),
+                array( 'status' => rest_authorization_required_code() )
+            );
+        }
+
+        if ( ! class_exists( PasswordLoginService::class ) ) {
+            return new WP_Error(
+                'tcn_rest_invalid_token',
+                __( 'The provided authentication token is invalid.', 'tcnapp-connector' ),
+                array( 'status' => rest_authorization_required_code() )
+            );
+        }
+
+        $payload = get_transient( PasswordLoginService::TOKEN_PREFIX . md5( $token ) );
+        if ( ! is_array( $payload ) || empty( $payload['user_id'] ) ) {
+            return new WP_Error(
+                'tcn_rest_token_expired',
+                __( 'The authentication token has expired or is invalid.', 'tcnapp-connector' ),
+                array( 'status' => rest_authorization_required_code() )
+            );
+        }
+
+        $user_id = (int) $payload['user_id'];
+        if ( $user_id <= 0 || ! get_user_by( 'id', $user_id ) ) {
+            return new WP_Error(
+                'tcn_rest_token_expired',
+                __( 'The authentication token has expired or is invalid.', 'tcnapp-connector' ),
+                array( 'status' => rest_authorization_required_code() )
+            );
+        }
+
+        wp_set_current_user( $user_id );
+
+        return $user_id;
+    }
+}

--- a/includes/Membership/MembershipModule.php
+++ b/includes/Membership/MembershipModule.php
@@ -1,6 +1,7 @@
 <?php
 namespace TCN\Platform\Membership;
 
+use TCN\Platform\Auth\TokenAuthenticator;
 use TCN\Platform\Support\Options;
 use WP_Error;
 use WP_REST_Request;
@@ -10,10 +11,16 @@ use WP_User;
 class MembershipModule {
     const COMMISSION_TABLE = 'tcn_mlm_commissions';
 
-    public function __construct( $modules = null ) {
+    /**
+     * @var TokenAuthenticator|null
+     */
+    protected $token_authenticator;
+
+    public function __construct( $modules = null, ?TokenAuthenticator $token_authenticator = null ) {
         // The membership module is always enabled, but the constructor accepts the
         // service container argument for forward compatibility with the module
         // toggles introduced in the unified plugin.
+        $this->token_authenticator = $token_authenticator;
     }
 
     public static function activate(): void {
@@ -102,9 +109,7 @@ class MembershipModule {
             array(
                 'methods'             => 'GET',
                 'callback'            => array( $this, 'rest_get_member_profile' ),
-                'permission_callback' => function () {
-                    return is_user_logged_in();
-                },
+                'permission_callback' => array( $this, 'rest_require_login' ),
             )
         );
 
@@ -114,9 +119,7 @@ class MembershipModule {
             array(
                 'methods'             => 'GET',
                 'callback'            => array( $this, 'rest_get_genealogy' ),
-                'permission_callback' => function () {
-                    return is_user_logged_in();
-                },
+                'permission_callback' => array( $this, 'rest_require_login' ),
             )
         );
 
@@ -126,9 +129,7 @@ class MembershipModule {
             array(
                 'methods'             => 'GET',
                 'callback'            => array( $this, 'rest_get_commissions' ),
-                'permission_callback' => function () {
-                    return is_user_logged_in();
-                },
+                'permission_callback' => array( $this, 'rest_require_login' ),
             )
         );
 
@@ -354,8 +355,29 @@ class MembershipModule {
         );
     }
 
-    public function rest_require_login(): bool {
-        return is_user_logged_in();
+    public function rest_require_login( WP_REST_Request $request ) {
+        $authenticated = $this->authenticate_with_token( $request );
+        if ( is_wp_error( $authenticated ) ) {
+            return $authenticated;
+        }
+
+        if ( $authenticated > 0 || is_user_logged_in() ) {
+            return true;
+        }
+
+        return new WP_Error(
+            'tcn_rest_unauthorized',
+            __( 'Authentication is required to access this resource.', 'tcnapp-connector' ),
+            array( 'status' => rest_authorization_required_code() )
+        );
+    }
+
+    protected function authenticate_with_token( WP_REST_Request $request ) {
+        if ( ! $this->token_authenticator ) {
+            return 0;
+        }
+
+        return $this->token_authenticator->authenticate_request( $request );
     }
 
     public function rest_get_membership_plans( WP_REST_Request $request ): array {

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -6,6 +6,7 @@ use TCN\Platform\Admin\ApiTesterPage;
 use TCN\Platform\Admin\LogPage;
 use TCN\Platform\Admin\SettingsPage;
 use TCN\Platform\Auth\PasswordLoginService;
+use TCN\Platform\Auth\TokenAuthenticator;
 use TCN\Platform\Membership\MembershipModule;
 use TCN\Platform\Rest\ProfileEndpoints;
 use TCN\Platform\Rest\WooCommerceEndpoints;
@@ -46,12 +47,14 @@ class Plugin {
     }
 
     protected function register_services(): void {
-        $this->services[] = new MembershipModule( $this->modules );
+        $token_authenticator = new TokenAuthenticator();
+
+        $this->services[] = new MembershipModule( $this->modules, $token_authenticator );
         $this->services[] = new ActivityMonitor();
         $this->services[] = new Updater();
 
         if ( $this->modules->is_enabled( Modules::MODULE_AUTH_LOGIN ) ) {
-            $this->services[] = new PasswordLoginService();
+            $this->services[] = new PasswordLoginService( $token_authenticator );
         } else {
             PasswordLoginService::register_compatibility_alias();
         }
@@ -60,7 +63,7 @@ class Plugin {
             $this->services[] = new WooCommerceEndpoints();
         }
 
-        $this->services[] = new ProfileEndpoints();
+        $this->services[] = new ProfileEndpoints( $token_authenticator );
 
         if ( is_admin() ) {
             $this->services[] = new SettingsPage( $this->modules );

--- a/includes/Rest/ProfileEndpoints.php
+++ b/includes/Rest/ProfileEndpoints.php
@@ -1,13 +1,22 @@
 <?php
 namespace TCN\Platform\Rest;
 
-use TCN\Platform\Auth\PasswordLoginService;
+use TCN\Platform\Auth\TokenAuthenticator;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
 
 class ProfileEndpoints {
+    /**
+     * @var TokenAuthenticator|null
+     */
+    protected $token_authenticator;
+
+    public function __construct( ?TokenAuthenticator $token_authenticator = null ) {
+        $this->token_authenticator = $token_authenticator;
+    }
+
     /**
      * Register WordPress hooks.
      */
@@ -41,7 +50,13 @@ class ProfileEndpoints {
         $user_id = get_current_user_id();
 
         if ( $user_id <= 0 ) {
-            $user_id = $this->authenticate_with_bearer_token( $request );
+            $authenticated = $this->authenticate_with_token( $request );
+
+            if ( is_wp_error( $authenticated ) ) {
+                return $authenticated;
+            }
+
+            $user_id = (int) $authenticated;
         }
 
         if ( $user_id <= 0 ) {
@@ -222,46 +237,12 @@ class ProfileEndpoints {
         return $response;
     }
 
-    /**
-     * Attempt to authenticate using a Password Login API bearer token.
-     */
-    protected function authenticate_with_bearer_token( WP_REST_Request $request ): int {
-        $header = $request->get_header( 'authorization' );
-
-        if ( empty( $header ) && isset( $_SERVER['HTTP_AUTHORIZATION'] ) ) {
-            $header = (string) wp_unslash( $_SERVER['HTTP_AUTHORIZATION'] );
-        }
-
-        if ( ! is_string( $header ) || '' === $header ) {
+    protected function authenticate_with_token( WP_REST_Request $request ) {
+        if ( ! $this->token_authenticator ) {
             return 0;
         }
 
-        if ( ! preg_match( '/Bearer\s+(.*)$/i', $header, $matches ) ) {
-            return 0;
-        }
-
-        $token = trim( (string) $matches[1] );
-        if ( '' === $token ) {
-            return 0;
-        }
-
-        if ( ! class_exists( PasswordLoginService::class ) ) {
-            return 0;
-        }
-
-        $payload = get_transient( PasswordLoginService::TOKEN_PREFIX . md5( $token ) );
-        if ( ! is_array( $payload ) || empty( $payload['user_id'] ) ) {
-            return 0;
-        }
-
-        $user_id = (int) $payload['user_id'];
-        if ( $user_id <= 0 || ! get_user_by( 'id', $user_id ) ) {
-            return 0;
-        }
-
-        wp_set_current_user( $user_id );
-
-        return $user_id;
+        return $this->token_authenticator->authenticate_request( $request );
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.40
+Stable tag: 0.3.41
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -93,6 +93,10 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.41 =
+* Enhancement: Reuse the Password Login bearer token authenticator across profile, membership, and password-change REST routes so API clients can authenticate with tokens or session cookies.
+* Fix: Return explicit `WP_Error` responses when bearer tokens are invalid or expired to keep REST error payloads consistent.
+
 = 0.3.40 =
 * Enhancement: Include the `WOOCOMMERCE_CONSUMER_KEY` and `WOOCOMMERCE_CONSUMER_SECRET` values in Password Login API responses so authenticated clients can automatically sign WooCommerce REST requests.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.40
+ * Version:           0.3.41
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.40' );
+define( 'TCN_PLATFORM_VERSION', '0.3.41' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- add a shared TokenAuthenticator helper for Password Login bearer tokens and consume it from profile, membership, and password APIs
- return WP_Error responses for invalid or expired tokens while allowing membership and password routes to authenticate via token or session
- wire the helper into the plugin bootstrap and update documentation with the new 0.3.41 release notes

## Testing
- php -l includes/Auth/TokenAuthenticator.php
- php -l includes/Auth/PasswordLoginService.php
- php -l includes/Membership/MembershipModule.php
- php -l includes/Rest/ProfileEndpoints.php

------
https://chatgpt.com/codex/tasks/task_e_68e24f0633148327be573a6ee57c5ed9