### PR TITLE
Relax avatar upload permissions for members

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.42
+- Relax the avatar upload permission gate so members without the `upload_files` capability can update their own profile photo while continuing to block cross-account uploads.
+
 ### 0.3.41
 - Centralise Password Login bearer token validation and reuse it across profile, membership, and password-change REST endpoints so mobile clients can authenticate with either tokens or session cookies.
 - Return REST-friendly `WP_Error` responses when tokens are invalid or expired to keep API feedback consistent.

--- a/includes/Rest/ProfileEndpoints.php
+++ b/includes/Rest/ProfileEndpoints.php
@@ -69,10 +69,16 @@ class ProfileEndpoints {
 
         $request->set_attribute( 'tcn_authenticated_user_id', $user_id );
 
-        if ( ! current_user_can( 'upload_files' ) ) {
+        if ( current_user_can( 'upload_files' ) ) {
+            return true;
+        }
+
+        $target_user_id = $this->determine_target_user_id( $request, $user_id );
+
+        if ( $target_user_id !== $user_id ) {
             return new WP_Error(
                 'tcn_rest_forbidden',
-                __( 'You do not have permission to upload files.', 'tcnapp-connector' ),
+                __( 'You can only upload an avatar for your own profile.', 'tcnapp-connector' ),
                 array( 'status' => 403 )
             );
         }
@@ -329,5 +335,31 @@ class ProfileEndpoints {
         }
 
         return 400;
+    }
+
+    /**
+     * Determine the profile ID targeted by the request.
+     */
+    protected function determine_target_user_id( WP_REST_Request $request, int $fallback ): int {
+        $candidates = array(
+            $request->get_param( 'user_id' ),
+            $request->get_param( 'id' ),
+            $request->get_param( 'user' ),
+            $request->get_attribute( 'tcn_profile_user_id' ),
+        );
+
+        foreach ( $candidates as $candidate ) {
+            if ( null === $candidate ) {
+                continue;
+            }
+
+            $candidate = (int) $candidate;
+
+            if ( $candidate > 0 ) {
+                return $candidate;
+            }
+        }
+
+        return $fallback;
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.41
+Stable tag: 0.3.42
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -93,6 +93,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.42 =
+* Fix: Allow authenticated members without the `upload_files` capability to update their own avatar while still blocking cross-profile uploads.
+
 = 0.3.41 =
 * Enhancement: Reuse the Password Login bearer token authenticator across profile, membership, and password-change REST routes so API clients can authenticate with tokens or session cookies.
 * Fix: Return explicit `WP_Error` responses when bearer tokens are invalid or expired to keep REST error payloads consistent.

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.41
+ * Version:           0.3.42
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.41' );
+define( 'TCN_PLATFORM_VERSION', '0.3.42' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- allow authenticated members without `upload_files` to post to the avatar endpoint when targeting their own profile while continuing to block cross-account uploads
- add a helper to resolve the targeted profile ID, update documentation, and bump the plugin to version 0.3.42

## Testing
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_68e2508e0660832784cd31f7f7bca633