### PR TITLE
Bump plugin version to 0.3.43

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.43
+- Maintenance: Bump the plugin version for the 0.3.43 release.
+
 ### 0.3.42
 - Relax the avatar upload permission gate so members without the `upload_files` capability can update their own profile photo while continuing to block cross-account uploads.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.42
+Stable tag: 0.3.43
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -93,6 +93,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.43 =
+* Maintenance: Bump the plugin version for the 0.3.43 release.
+
 = 0.3.42 =
 * Fix: Allow authenticated members without the `upload_files` capability to update their own avatar while still blocking cross-profile uploads.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.42
+ * Version:           0.3.43
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.42' );
+define( 'TCN_PLATFORM_VERSION', '0.3.43' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- update the plugin header and version constant to 0.3.43
- bump the WordPress readme stable tag and changelog for the 0.3.43 release
- add a matching 0.3.43 entry to the project README release notes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e256d4153083279783a5feb464689e