### PR TITLE
Add Activity Log download export

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.44
+- Feature: Add a Download Log button that exports the complete Activity Log to a timestamped text file for offline auditing.
+
 ### 0.3.43
 - Maintenance: Bump the plugin version for the 0.3.43 release.
 

--- a/admin/css/tcn-platform-admin.css
+++ b/admin/css/tcn-platform-admin.css
@@ -467,7 +467,12 @@
 .tcn-platform-log-actions {
     display: flex;
     justify-content: flex-end;
+    gap: 12px;
     margin-bottom: 18px;
+}
+
+.tcn-platform-log-action-form {
+    margin: 0;
 }
 
 .tcn-platform-log-actions .button {

--- a/includes/Admin/LogPage.php
+++ b/includes/Admin/LogPage.php
@@ -7,6 +7,7 @@ use function __;
 use function add_query_arg;
 use function add_submenu_page;
 use function admin_url;
+use function current_time;
 use function current_user_can;
 use function date_i18n;
 use function esc_attr;
@@ -15,6 +16,8 @@ use function esc_html__;
 use function esc_html_e;
 use function esc_url;
 use function get_option;
+use function gmdate;
+use function nocache_headers;
 use function submit_button;
 use function wp_die;
 use function wp_get_current_user;
@@ -30,6 +33,7 @@ class LogPage {
     public function register(): void {
         add_action( 'admin_menu', array( $this, 'register_menu' ) );
         add_action( 'admin_post_tcn_platform_clear_logs', array( $this, 'handle_clear_logs' ) );
+        add_action( 'admin_post_tcn_platform_download_logs', array( $this, 'handle_download_logs' ) );
     }
 
     public function register_menu(): void {
@@ -104,11 +108,19 @@ class LogPage {
             <?php endif; ?>
 
             <div class="tcn-platform-panel">
-                <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="tcn-platform-log-actions">
-                    <?php wp_nonce_field( 'tcn_platform_clear_logs', 'tcn_platform_clear_logs_nonce' ); ?>
-                    <input type="hidden" name="action" value="tcn_platform_clear_logs" />
-                    <?php submit_button( __( 'Clear Log', 'tcnapp-connector' ), 'delete', 'submit', false ); ?>
-                </form>
+                <div class="tcn-platform-log-actions">
+                    <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="tcn-platform-log-action-form">
+                        <?php wp_nonce_field( 'tcn_platform_clear_logs', 'tcn_platform_clear_logs_nonce' ); ?>
+                        <input type="hidden" name="action" value="tcn_platform_clear_logs" />
+                        <?php submit_button( __( 'Clear Log', 'tcnapp-connector' ), 'delete', 'submit', false ); ?>
+                    </form>
+
+                    <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="tcn-platform-log-action-form">
+                        <?php wp_nonce_field( 'tcn_platform_download_logs', 'tcn_platform_download_logs_nonce' ); ?>
+                        <input type="hidden" name="action" value="tcn_platform_download_logs" />
+                        <?php submit_button( __( 'Download Log', 'tcnapp-connector' ), 'secondary', 'submit', false ); ?>
+                    </form>
+                </div>
 
                 <div class="tcn-platform-log-table-wrapper">
                     <table id="tcn-platform-log-table" class="widefat fixed striped tcn-platform-log-table display nowrap" style="width:100%">
@@ -142,6 +154,31 @@ class LogPage {
             </div>
         </div>
         <?php
+    }
+
+    public function handle_download_logs(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'You do not have permission to access this page.', 'tcnapp-connector' ) );
+        }
+
+        $nonce = isset( $_POST['tcn_platform_download_logs_nonce'] ) ? wp_unslash( $_POST['tcn_platform_download_logs_nonce'] ) : '';
+        if ( empty( $nonce ) || ! wp_verify_nonce( $nonce, 'tcn_platform_download_logs' ) ) {
+            wp_die( esc_html__( 'Invalid request.', 'tcnapp-connector' ) );
+        }
+
+        if ( ! RestrictedAccess::has_access( 'tcn-platform-logs' ) ) {
+            wp_die( esc_html__( 'Please unlock the Activity Log before performing this action.', 'tcnapp-connector' ) );
+        }
+
+        $logs     = Logger::get_logs();
+        $filename = sprintf( 'tcn-platform-activity-log-%s.txt', gmdate( 'Ymd-His' ) );
+
+        nocache_headers();
+        header( 'Content-Type: text/plain; charset=utf-8' );
+        header( 'Content-Disposition: attachment; filename="' . $filename . '"' );
+
+        echo $this->build_log_export( $logs ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        exit;
     }
 
     protected function format_time( $timestamp ): string {
@@ -308,5 +345,56 @@ class LogPage {
         }
 
         return ucwords( preg_replace( '/[_\-.]+/', ' ', (string) $key ) );
+    }
+
+    protected function build_log_export( array $logs ): string {
+        $lines   = array();
+        $lines[] = 'TCN Platform Activity Log';
+        /* translators: %s: Date and time the log export was generated. */
+        $lines[] = sprintf( __( 'Generated: %s', 'tcnapp-connector' ), $this->format_time( current_time( 'timestamp', true ) ) );
+        $lines[] = str_repeat( '=', 80 );
+        $lines[] = '';
+
+        if ( empty( $logs ) ) {
+            $lines[] = __( 'No activity recorded yet.', 'tcnapp-connector' );
+            return implode( "\n", $lines ) . "\n";
+        }
+
+        foreach ( $logs as $entry ) {
+            $timestamp = isset( $entry['time'] ) ? (int) $entry['time'] : 0;
+            $lines[]   = sprintf(
+                '[%1$s] %2$s — %3$s',
+                $this->format_time( $timestamp ),
+                $this->format_source( $entry['source'] ?? '' ),
+                $entry['message'] ?? ''
+            );
+
+            $context_export = $this->prepare_context_export( $entry['context'] ?? array() );
+            if ( $context_export ) {
+                $lines[] = __( 'Context:', 'tcnapp-connector' );
+                $lines[] = $context_export;
+            }
+
+            $lines[] = '';
+        }
+
+        return implode( "\n", $lines ) . "\n";
+    }
+
+    protected function prepare_context_export( $context ): string {
+        if ( empty( $context ) ) {
+            return '';
+        }
+
+        $encoded = wp_json_encode( $context, JSON_PRETTY_PRINT );
+        if ( false === $encoded ) {
+            $encoded = wp_json_encode( $context );
+        }
+
+        if ( false === $encoded || null === $encoded ) {
+            return '';
+        }
+
+        return (string) $encoded;
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.43
+Stable tag: 0.3.44
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -93,6 +93,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.44 =
+* Feature: Add a download button that exports the entire Activity Log as a timestamped text file so administrators can archive full audit trails.
+
 = 0.3.43 =
 * Maintenance: Bump the plugin version for the 0.3.43 release.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.43
+ * Version:           0.3.44
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.43' );
+define( 'TCN_PLATFORM_VERSION', '0.3.44' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- add an admin-post handler that outputs the Activity Log as a timestamped text download
- expose a Download Log button next to Clear Log and tweak the layout spacing for the controls
- bump the plugin version to 0.3.44 and update the accompanying readme files

## Testing
- php -l includes/Admin/LogPage.php

------
https://chatgpt.com/codex/tasks/task_e_68e25b2292608327aecb07d8cb69cc61