### PR TITLE
Add REST bearer token helpers and diagnostic endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.45
+- Feature: Issue week-long bearer tokens on login responses, expose a `/gn/v1/me` profile endpoint, and add a `/gn/v1/log` ingestor for mobile diagnostics.
+
 ### 0.3.44
 - Feature: Add a Download Log button that exports the complete Activity Log to a timestamped text file for offline auditing.
 

--- a/includes/Auth/PasswordLoginService.php
+++ b/includes/Auth/PasswordLoginService.php
@@ -92,6 +92,59 @@ class PasswordLoginService {
                 'permission_callback' => array( $this, 'require_login_or_token' ),
             )
         );
+
+        register_rest_route(
+            'gn/v1',
+            '/me',
+            array(
+                'methods'             => 'GET',
+                'callback'            => function( WP_REST_Request $req ) {
+                    $hdr = $req->get_header( 'authorization' );
+                    if ( ! $hdr || 0 !== stripos( $hdr, 'Bearer ' ) ) {
+                        return new WP_Error( 'gn_unauth', 'Missing bearer', array( 'status' => 401 ) );
+                    }
+
+                    $token   = trim( substr( $hdr, 7 ) );
+                    $user_id = $this->validate_api_token( $token );
+                    if ( ! $user_id ) {
+                        return new WP_Error( 'gn_unauth', 'Invalid token', array( 'status' => 401 ) );
+                    }
+
+                    $user = get_user_by( 'ID', $user_id );
+
+                    return array(
+                        'user' => $this->prepare_user_payload( $user ),
+                    );
+                },
+                'permission_callback' => '__return_true',
+            )
+        );
+
+        register_rest_route(
+            'gn/v1',
+            '/log',
+            array(
+                'methods'             => 'POST',
+                'callback'            => function( WP_REST_Request $r ) {
+                    $level   = sanitize_text_field( $r->get_param( 'log_level' ) ?: 'info' );
+                    $message = sanitize_text_field( $r->get_param( 'log_message' ) ?: '(no message)' );
+                    $source  = sanitize_text_field( $r->get_param( 'log_source' ) ?: 'mobile-app' );
+                    $params  = $r->get_param( 'log_params' );
+
+                    \TCN\Platform\Support\Logger::log(
+                        $source,
+                        $message,
+                        array(
+                            'level'  => $level,
+                            'params' => is_array( $params ) ? $params : array(),
+                        )
+                    );
+
+                    return array( 'ok' => true );
+                },
+                'permission_callback' => '__return_true',
+            )
+        );
     }
 
     public function handle_login( WP_REST_Request $request ) {
@@ -134,7 +187,6 @@ class PasswordLoginService {
             $token = $this->issue_login_token( $user->ID );
 
             $response['token']      = $token['token'];
-            $response['expires_in'] = $token['expires_in'];
             $response['redirect']   = add_query_arg(
                 array(
                     'action' => 'gn_token_login',
@@ -143,6 +195,11 @@ class PasswordLoginService {
                 wp_login_url()
             );
         }
+
+        $api                     = $this->issue_api_token( $user->ID );
+        $response['api_token']    = $api['token'];
+        $response['expires_in']   = $api['expires_in'];
+        unset( $response['redirect'] );
 
         $woocommerce_credentials = $this->get_woocommerce_credentials();
         if ( ! empty( $woocommerce_credentials ) ) {
@@ -510,6 +567,34 @@ class PasswordLoginService {
             'token'      => $token,
             'expires_in' => $lifetime,
         );
+    }
+
+    protected function issue_api_token( int $user_id ): array {
+        $lifetime = DAY_IN_SECONDS * 7;
+        $token    = wp_generate_password( 64, false );
+
+        set_transient(
+            'tcn_api_tok_' . md5( $token ),
+            array(
+                'user_id' => $user_id,
+                'exp'     => time() + $lifetime,
+            ),
+            $lifetime
+        );
+
+        return array(
+            'token'      => $token,
+            'expires_in' => $lifetime,
+        );
+    }
+
+    protected function validate_api_token( string $token ) {
+        $t = get_transient( 'tcn_api_tok_' . md5( $token ) );
+        if ( empty( $t ) || empty( $t['user_id'] ) || time() > (int) $t['exp'] ) {
+            return false;
+        }
+
+        return (int) $t['user_id'];
     }
 
     protected function build_token_key( string $token ): string {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.44
+Stable tag: 0.3.45
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -93,6 +93,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.45 =
+* Feature: Add seven-day bearer tokens to REST login responses, expose a `/gn/v1/me` profile endpoint, and provide a `/gn/v1/log` collector for mobile diagnostics.
+
 = 0.3.44 =
 * Feature: Add a download button that exports the entire Activity Log as a timestamped text file so administrators can archive full audit trails.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.44
+ * Version:           0.3.45
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.44' );
+define( 'TCN_PLATFORM_VERSION', '0.3.45' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- issue seven-day API bearer tokens alongside password login responses and remove legacy redirects
- register new `/gn/v1/me` and `/gn/v1/log` REST endpoints for profile lookups and mobile diagnostics
- bump the plugin version to 0.3.45 and document the release

## Testing
- php -l includes/Auth/PasswordLoginService.php

------
https://chatgpt.com/codex/tasks/task_e_68e263854a48832794222aeb4c8de385