### PR TITLE
Expand API tester coverage and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.46
+- Enhancement: Expand the API tester presets to cover every REST endpoint, including `/gn/v1/me` and `/gn/v1/log`, so admins can prefill requests for authentication, membership, MLM, and WooCommerce bridges.
+
 ### 0.3.45
 - Feature: Issue week-long bearer tokens on login responses, expose a `/gn/v1/me` profile endpoint, and add a `/gn/v1/log` ingestor for mobile diagnostics.
 

--- a/includes/Admin/ApiTesterPage.php
+++ b/includes/Admin/ApiTesterPage.php
@@ -375,6 +375,8 @@ class ApiTesterPage {
         $reset_url        = home_url( '/wp-json/gn/v1/reset-password' );
         $change_url       = home_url( '/wp-json/gn/v1/change-password' );
         $avatar_url       = home_url( '/wp-json/gn/v1/profile/avatar' );
+        $me_url           = home_url( '/wp-json/gn/v1/me' );
+        $log_url          = home_url( '/wp-json/gn/v1/log' );
         $plans_url        = home_url( '/wp-json/gn/v1/memberships/plans' );
         $stripe_intent    = home_url( '/wp-json/gn/v1/memberships/stripe-intent' );
         $confirm_upgrade  = home_url( '/wp-json/gn/v1/memberships/confirm' );
@@ -502,6 +504,31 @@ class ApiTesterPage {
                 ) ?: '',
             ),
             array(
+                'method'      => 'GET',
+                'url'         => $me_url,
+                'description' => __( 'Fetch the authenticated user payload using an API token.', 'tcnapp-connector' ),
+                'note'        => __( 'Requires Authorization: Bearer header with a valid API token issued by /login.', 'tcnapp-connector' ),
+                'headers'     => wp_json_encode(
+                    array(
+                        'Authorization' => 'Bearer paste-api-token-here',
+                    ),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                ) ?: '',
+                'body'        => '',
+                'response'    => wp_json_encode(
+                    array(
+                        'user' => array(
+                            'id'         => 123,
+                            'email'      => 'member@example.com',
+                            'first_name' => 'Member',
+                            'last_name'  => 'Example',
+                            'roles'      => array( 'customer' ),
+                        ),
+                    ),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                ) ?: '',
+            ),
+            array(
                 'method'      => 'POST',
                 'url'         => $avatar_url,
                 'description' => __( 'Upload a profile photo and refresh the user session payload.', 'tcnapp-connector' ),
@@ -529,6 +556,36 @@ class ApiTesterPage {
                             '48' => 'https://example.com/avatar-48x48.jpg',
                             '96' => 'https://example.com/avatar-96x96.jpg',
                         ),
+                    ),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                ) ?: '',
+            ),
+            array(
+                'method'      => 'POST',
+                'url'         => $log_url,
+                'description' => __( 'Send diagnostic log entries from remote clients.', 'tcnapp-connector' ),
+                'note'        => __( 'Public endpoint; include contextual fields to help with troubleshooting.', 'tcnapp-connector' ),
+                'headers'     => wp_json_encode(
+                    array(
+                        'Content-Type' => 'application/json',
+                    ),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                ) ?: '',
+                'body'        => wp_json_encode(
+                    array(
+                        'log_level'   => 'info',
+                        'log_source'  => 'mobile-app',
+                        'log_message' => 'User opened the dashboard.',
+                        'log_params'  => array(
+                            'user_id' => 123,
+                            'screen'  => 'dashboard',
+                        ),
+                    ),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                ) ?: '',
+                'response'    => wp_json_encode(
+                    array(
+                        'ok' => true,
                     ),
                     JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
                 ) ?: '',

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.45
+Stable tag: 0.3.46
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -93,6 +93,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.46 =
+* Enhancement: Expand the API tester presets to include every REST endpoint—authentication, membership, MLM, and WooCommerce—so administrators can populate requests with a single click.
+
 = 0.3.45 =
 * Feature: Add seven-day bearer tokens to REST login responses, expose a `/gn/v1/me` profile endpoint, and provide a `/gn/v1/log` collector for mobile diagnostics.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.45
+ * Version:           0.3.46
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.45' );
+define( 'TCN_PLATFORM_VERSION', '0.3.46' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- add presets for the `/gn/v1/me` and `/gn/v1/log` endpoints so the API tester includes every available route
- bump the plugin version to 0.3.46 and document the release in both readme files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e265269f348327a24dd82fa05022e3