### PR TITLE
Support API bearer tokens and bump version to 0.3.48

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.48
+- Accept long-lived Password Login API bearer tokens in addition to one-time hand-off tokens so REST requests authenticated from the mobile app can reuse the stored `api_token` without falling back to cookie flows.
+- Document the shared API token prefix in code to keep authenticator lookups aligned.
+
 ### 0.3.47
 - Switch the mobile login flow to rely on `mode=token` hand-offs and extend the login token lifetime to a full week so members can finish authentication even if the browser redirect is delayed.
 

--- a/includes/Auth/PasswordLoginService.php
+++ b/includes/Auth/PasswordLoginService.php
@@ -10,6 +10,7 @@ use WP_User;
 class PasswordLoginService {
     const RATE_LIMIT_PREFIX = 'gn_login_rate_';
     const TOKEN_PREFIX      = 'gn_login_token_';
+    const API_TOKEN_PREFIX  = 'tcn_api_tok_';
     const RESET_META_KEY    = '_gn_password_api_reset_code';
 
     /**
@@ -574,7 +575,7 @@ class PasswordLoginService {
         $token    = wp_generate_password( 64, false );
 
         set_transient(
-            'tcn_api_tok_' . md5( $token ),
+            self::API_TOKEN_PREFIX . md5( $token ),
             array(
                 'user_id' => $user_id,
                 'exp'     => time() + $lifetime,
@@ -589,7 +590,7 @@ class PasswordLoginService {
     }
 
     protected function validate_api_token( string $token ) {
-        $t = get_transient( 'tcn_api_tok_' . md5( $token ) );
+        $t = get_transient( self::API_TOKEN_PREFIX . md5( $token ) );
         if ( empty( $t ) || empty( $t['user_id'] ) || time() > (int) $t['exp'] ) {
             return false;
         }

--- a/includes/Auth/TokenAuthenticator.php
+++ b/includes/Auth/TokenAuthenticator.php
@@ -65,18 +65,21 @@ class TokenAuthenticator {
             );
         }
 
-        $payload = get_transient( PasswordLoginService::TOKEN_PREFIX . md5( $token ) );
-        if ( ! is_array( $payload ) || empty( $payload['user_id'] ) ) {
-            $this->log_debug(
-                'authenticate_request token payload missing or expired',
-                array( 'token_hash' => md5( $token ) )
-            );
+        $token_hash = md5( $token );
+        $token_type = 'login';
 
-            return new WP_Error(
-                'tcn_rest_token_expired',
-                __( 'The authentication token has expired or is invalid.', 'tcnapp-connector' ),
-                array( 'status' => rest_authorization_required_code() )
-            );
+        $payload = $this->get_login_token_payload( $token_hash );
+        if ( false === $payload ) {
+            $token_type = 'api';
+            $payload    = $this->get_api_token_payload( $token_hash );
+
+            if ( false === $payload ) {
+                return new WP_Error(
+                    'tcn_rest_token_expired',
+                    __( 'The authentication token has expired or is invalid.', 'tcnapp-connector' ),
+                    array( 'status' => rest_authorization_required_code() )
+                );
+            }
         }
 
         $user_id = (int) $payload['user_id'];
@@ -84,8 +87,9 @@ class TokenAuthenticator {
             $this->log_debug(
                 'authenticate_request token payload user invalid',
                 array(
-                    'token_hash' => md5( $token ),
+                    'token_hash' => $token_hash,
                     'user_id'    => $user_id,
+                    'token_type' => $token_type,
                 )
             );
 
@@ -102,11 +106,67 @@ class TokenAuthenticator {
             'authenticate_request succeeded',
             array(
                 'user_id'    => $user_id,
-                'token_hash' => md5( $token ),
+                'token_hash' => $token_hash,
+                'token_type' => $token_type,
             )
         );
 
         return $user_id;
+    }
+
+    /**
+     * Retrieve the payload for a login hand-off token.
+     *
+     * @return array<string, mixed>|false
+     */
+    protected function get_login_token_payload( string $token_hash ) {
+        $payload = get_transient( PasswordLoginService::TOKEN_PREFIX . $token_hash );
+
+        if ( ! is_array( $payload ) || empty( $payload['user_id'] ) ) {
+            $this->log_debug(
+                'authenticate_request login token payload missing or expired',
+                array( 'token_hash' => $token_hash )
+            );
+
+            return false;
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Retrieve the payload for a long-lived API bearer token.
+     *
+     * @return array<string, mixed>|false
+     */
+    protected function get_api_token_payload( string $token_hash ) {
+        $payload = get_transient( PasswordLoginService::API_TOKEN_PREFIX . $token_hash );
+
+        if ( ! is_array( $payload ) || empty( $payload['user_id'] ) ) {
+            $this->log_debug(
+                'authenticate_request api token payload missing',
+                array( 'token_hash' => $token_hash )
+            );
+
+            return false;
+        }
+
+        $expires = isset( $payload['exp'] ) ? (int) $payload['exp'] : 0;
+        if ( $expires && time() > $expires ) {
+            $this->log_debug(
+                'authenticate_request api token payload expired',
+                array(
+                    'token_hash' => $token_hash,
+                    'expired_at' => $expires,
+                )
+            );
+
+            delete_transient( PasswordLoginService::API_TOKEN_PREFIX . $token_hash );
+
+            return false;
+        }
+
+        return $payload;
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.47
+Stable tag: 0.3.48
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -93,6 +93,10 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.48 =
+* Fix: Allow REST requests authenticated with the Password Login API bearer token to validate using either the one-time login token or the long-lived `api_token`, ensuring mobile clients can reuse stored bearer credentials.
+* Maintenance: Expose a class constant for the API token transient prefix so authentication helpers stay in sync.
+
 = 0.3.47 =
 * Change the Password Login API to prefer `mode=token` flows and extend the login token lifetime to one week so delayed hand-offs still succeed.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.47
+ * Version:           0.3.48
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.47' );
+define( 'TCN_PLATFORM_VERSION', '0.3.48' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- allow the REST token authenticator to validate both login hand-off tokens and long-lived api_token values issued by the Password Login API
- centralize the API token transient prefix via a class constant and refresh the public docs/readmes for the 0.3.48 release
- bump the plugin version metadata to 0.3.48

## Testing
- php -l includes/Auth/PasswordLoginService.php
- php -l includes/Auth/TokenAuthenticator.php

------
https://chatgpt.com/codex/tasks/task_e_68e28fc2d42c8327ad74f82a279913a0