### PR TITLE
Add App User role for API members

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.50
+- Add a dedicated App User role with upload permissions and automatically assign it to API-registered customers to unblock avatar uploads.
+
 ### 0.3.49
 - Remove the cookie-based login mode so Password Login API responses always issue one-time hand-off tokens.
 

--- a/docs/TCN_PLATFORM_REFERENCE.md
+++ b/docs/TCN_PLATFORM_REFERENCE.md
@@ -267,7 +267,7 @@ The tables below enumerate every method, its visibility, parameters, return valu
 | `render_product_level_field()` | public | Adds product data panel field for membership level association. | — | void | Uses `woocommerce_wp_select`. |
 | `save_product_level_field( int $product_id )` | public | Persists membership level selection from product edit screen. | `$product_id` | void | Validates against defined levels. |
 | `assign_sponsor_from_cookie( int $user_id )` | public | Applies sponsor cookie to new registrations, updates metrics. | `$user_id` | void | Hooked to `user_register`. |
-| `ensure_customer_role( int $user_id )` | protected | Adds WooCommerce `customer` role, removes `subscriber` when redundant. | `$user_id` | void | — |
+| `ensure_customer_role( int $user_id )` | protected | Ensures App User + WooCommerce `customer` roles exist, removes `subscriber` when redundant. | `$user_id` | void | — |
 | `maybe_create_welcome_order( int $user_id, WP_REST_Request $request )` | protected | Auto-creates completed WooCommerce order for Blue tier on API signup. | `$user_id`, `$request` | void | Stores order ID in user meta. |
 | `get_membership_product_id( string $level, ?array $products = null )` | protected | Resolves product ID for membership level, with slug fallback. | `$level`, optional product map | int | Prefers mapping from `get_membership_products()`, falls back to known slugs (`blue-membership`, `gold-membership`, etc.). |
 | `get_product_id_by_slug( string $slug )` | protected | Finds product by slug. | `$slug` | int | Returns 0 when not found. |

--- a/includes/Activator.php
+++ b/includes/Activator.php
@@ -4,11 +4,13 @@ namespace TCN\Platform;
 use TCN\Platform\Membership\MembershipModule;
 use TCN\Platform\Support\Modules;
 use TCN\Platform\Support\Options;
+use TCN\Platform\Support\Roles;
 
 class Activator {
     public static function activate(): void {
         Options::ensure_defaults();
         Modules::seed_defaults();
+        Roles::ensure_roles();
         MembershipModule::activate();
 
         do_action( 'tcn_platform_activated' );

--- a/includes/Membership/MembershipModule.php
+++ b/includes/Membership/MembershipModule.php
@@ -3,6 +3,7 @@ namespace TCN\Platform\Membership;
 
 use TCN\Platform\Auth\TokenAuthenticator;
 use TCN\Platform\Support\Options;
+use TCN\Platform\Support\Roles;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Server;
@@ -747,6 +748,8 @@ class MembershipModule {
         if ( ! $user instanceof WP_User ) {
             return;
         }
+
+        Roles::maybe_assign_app_user_role( $user );
 
         if ( ! in_array( 'customer', $user->roles, true ) ) {
             $user->add_role( 'customer' );

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -11,6 +11,7 @@ use TCN\Platform\Membership\MembershipModule;
 use TCN\Platform\Rest\ProfileEndpoints;
 use TCN\Platform\Rest\WooCommerceEndpoints;
 use TCN\Platform\Support\Modules;
+use TCN\Platform\Support\Roles;
 use TCN\Platform\Support\ActivityMonitor;
 use TCN\Platform\Support\Updater;
 
@@ -31,6 +32,8 @@ class Plugin {
 
     public function boot(): void {
         add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
+        Roles::ensure_roles();
+        add_action( 'init', array( Roles::class, 'ensure_roles' ) );
         $this->register_services();
 
         foreach ( $this->services as $service ) {

--- a/includes/Support/Roles.php
+++ b/includes/Support/Roles.php
@@ -1,0 +1,68 @@
+<?php
+namespace TCN\Platform\Support;
+
+use WP_Role;
+use WP_User;
+
+class Roles {
+    const APP_USER_ROLE = 'tcn_app_user';
+
+    /**
+     * Ensure custom roles exist with the expected capabilities.
+     */
+    public static function ensure_roles(): void {
+        self::ensure_app_user_role();
+    }
+
+    /**
+     * Guarantee the App User role is present and provisioned correctly.
+     */
+    protected static function ensure_app_user_role(): void {
+        $capabilities = self::get_app_user_capabilities();
+
+        $role = get_role( self::APP_USER_ROLE );
+
+        if ( ! $role instanceof WP_Role ) {
+            add_role( self::APP_USER_ROLE, __( 'App User', 'tcnapp-connector' ), $capabilities );
+            return;
+        }
+
+        foreach ( $capabilities as $capability => $grant ) {
+            if ( $grant ) {
+                if ( ! $role->has_cap( $capability ) ) {
+                    $role->add_cap( $capability );
+                }
+                continue;
+            }
+
+            if ( $role->has_cap( $capability ) ) {
+                $role->remove_cap( $capability );
+            }
+        }
+    }
+
+    /**
+     * Assign the App User role to a user when missing.
+     */
+    public static function maybe_assign_app_user_role( $user ): void {
+        if ( ! $user instanceof WP_User ) {
+            return;
+        }
+
+        if ( in_array( self::APP_USER_ROLE, $user->roles, true ) ) {
+            return;
+        }
+
+        $user->add_role( self::APP_USER_ROLE );
+    }
+
+    /**
+     * Retrieve the capabilities granted to the App User role.
+     */
+    protected static function get_app_user_capabilities(): array {
+        return array(
+            'read'         => true,
+            'upload_files' => true,
+        );
+    }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.49
+Stable tag: 0.3.50
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -93,6 +93,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.50 =
+* Enhancement: Add a dedicated App User role with upload permissions and automatically assign it to API-registered customers so avatar uploads succeed without granting full customer caps.
+
 = 0.3.49 =
 * Fix: Remove the cookie-based login mode so Password Login API responses always issue one-time hand-off tokens.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.49
+ * Version:           0.3.50
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.49' );
+define( 'TCN_PLATFORM_VERSION', '0.3.50' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- add a reusable support helper that seeds an App User role with upload permissions and keeps its capabilities in sync
- ensure the new role is provisioned during activation/runtime and assigned to API-registered members alongside the WooCommerce customer role
- update documentation and changelog details while bumping the plugin version to 0.3.50

## Testing
- php -l includes/Support/Roles.php
- php -l includes/Membership/MembershipModule.php
- php -l includes/Plugin.php
- php -l includes/Activator.php

------
https://chatgpt.com/codex/tasks/task_e_68e29e34b3148327ad0e12be5798eb5f