### PR TITLE
Handle redirected authorization headers in TokenAuthenticator

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.51
+- Accept bearer tokens passed through `REDIRECT_HTTP_AUTHORIZATION` or `AUTHORIZATION` when FastCGI/proxy setups strip the standard header so API clients keep authenticating successfully.
+- Add a lightweight test harness that exercises the new header fallbacks to prevent regressions.
+
 ### 0.3.50
 - Add a dedicated App User role with upload permissions and automatically assign it to API-registered customers to unblock avatar uploads.
 

--- a/includes/Auth/TokenAuthenticator.php
+++ b/includes/Auth/TokenAuthenticator.php
@@ -13,16 +13,29 @@ class TokenAuthenticator {
     public function authenticate_request( WP_REST_Request $request ) {
         $header = $request->get_header( 'authorization' );
 
+        $server_keys = array(
+            'HTTP_AUTHORIZATION',
+            'REDIRECT_HTTP_AUTHORIZATION',
+            'AUTHORIZATION',
+        );
+
         $this->log_debug(
             'authenticate_request invoked',
             array(
                 'has_header'             => is_string( $header ) && '' !== trim( $header ),
                 'server_header_present'  => isset( $_SERVER['HTTP_AUTHORIZATION'] ),
+                'redirect_header_present' => isset( $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ),
+                'alt_header_present'      => isset( $_SERVER['AUTHORIZATION'] ),
             )
         );
 
-        if ( empty( $header ) && isset( $_SERVER['HTTP_AUTHORIZATION'] ) ) {
-            $header = (string) wp_unslash( $_SERVER['HTTP_AUTHORIZATION'] );
+        if ( empty( $header ) ) {
+            foreach ( $server_keys as $server_key ) {
+                if ( isset( $_SERVER[ $server_key ] ) && '' !== trim( (string) $_SERVER[ $server_key ] ) ) {
+                    $header = (string) wp_unslash( $_SERVER[ $server_key ] );
+                    break;
+                }
+            }
         }
 
         if ( ! is_string( $header ) || '' === trim( $header ) ) {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="TCN Platform Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.50
+Stable tag: 0.3.51
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -93,6 +93,10 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.51 =
+* Fix: Accept bearer tokens passed via `REDIRECT_HTTP_AUTHORIZATION` or `AUTHORIZATION` server headers so reverse proxies and FastCGI setups authenticate correctly instead of reporting missing tokens.
+* Test: Add coverage for the new header fallbacks to guard against regressions when WordPress or hosting environments adjust how they expose authorization headers.
+
 = 0.3.50 =
 * Enhancement: Add a dedicated App User role with upload permissions and automatically assign it to API-registered customers so avatar uploads succeed without granting full customer caps.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.50
+ * Version:           0.3.51
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.50' );
+define( 'TCN_PLATFORM_VERSION', '0.3.51' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/tests/TokenAuthenticatorTest.php
+++ b/tests/TokenAuthenticatorTest.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use TCN\Platform\Auth\TokenAuthenticator;
+
+final class TokenAuthenticatorTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+        $_SERVER = array();
+        unset( $GLOBALS['current_user_id'] );
+    }
+
+    public function test_authenticates_with_redirect_header_fallback(): void {
+        $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] = 'Bearer redirect-token';
+
+        $authenticator = $this->create_authenticator_expectation( 'redirect-token' );
+        $request       = new WP_REST_Request();
+
+        $result = $authenticator->authenticate_request( $request );
+
+        $this->assertSame( 123, $result );
+        $this->assertSame( 123, $GLOBALS['current_user_id'] ?? null );
+        $this->assertContains( md5( 'redirect-token' ), $authenticator->received_token_hashes );
+    }
+
+    public function test_authenticates_with_authorization_header_fallback(): void {
+        $_SERVER['AUTHORIZATION'] = 'Bearer alt-token';
+
+        $authenticator = $this->create_authenticator_expectation( 'alt-token' );
+        $request       = new WP_REST_Request();
+
+        $result = $authenticator->authenticate_request( $request );
+
+        $this->assertSame( 123, $result );
+        $this->assertSame( 123, $GLOBALS['current_user_id'] ?? null );
+        $this->assertContains( md5( 'alt-token' ), $authenticator->received_token_hashes );
+    }
+
+    private function create_authenticator_expectation( string $expected_token ): TokenAuthenticator {
+        return new class( $expected_token ) extends TokenAuthenticator {
+            /**
+             * @var string
+             */
+            private $expected_token;
+
+            /**
+             * @var array<int, string>
+             */
+            public $received_token_hashes = array();
+
+            public function __construct( string $expected_token ) {
+                $this->expected_token = $expected_token;
+            }
+
+            protected function get_login_token_payload( string $token_hash ) {
+                $this->received_token_hashes[] = $token_hash;
+
+                if ( $token_hash === md5( $this->expected_token ) ) {
+                    return array( 'user_id' => 123 );
+                }
+
+                return false;
+            }
+
+            protected function get_api_token_payload( string $token_hash ) {
+                $this->received_token_hashes[] = $token_hash;
+
+                return false;
+            }
+
+            protected function log_debug( string $message, array $context = array() ): void {
+                // Silence debug output during tests.
+            }
+        };
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,139 @@
+<?php
+declare(strict_types=1);
+
+namespace PHPUnit\Framework {
+    if ( ! class_exists( AssertionFailedError::class, false ) ) {
+        class AssertionFailedError extends \RuntimeException {}
+    }
+
+    if ( ! class_exists( TestCase::class, false ) ) {
+        abstract class TestCase {
+            protected function setUp(): void {}
+
+            protected function tearDown(): void {}
+
+            public function runTestMethod( string $method ): void {
+                $this->setUp();
+
+                try {
+                    $this->$method();
+                } finally {
+                    $this->tearDown();
+                }
+            }
+
+            protected function fail( string $message ): void {
+                throw new AssertionFailedError( $message );
+            }
+
+            protected function assertSame( $expected, $actual, string $message = '' ): void {
+                if ( $expected !== $actual ) {
+                    $message = $message ?: sprintf(
+                        'Failed asserting that %s is identical to %s.',
+                        var_export( $actual, true ),
+                        var_export( $expected, true )
+                    );
+
+                    $this->fail( $message );
+                }
+            }
+
+            protected function assertContains( $needle, $haystack, string $message = '' ): void {
+                $found = false;
+
+                if ( is_array( $haystack ) ) {
+                    $found = in_array( $needle, $haystack, true );
+                } elseif ( is_string( $haystack ) ) {
+                    $found = false !== strpos( $haystack, (string) $needle );
+                }
+
+                if ( ! $found ) {
+                    $message = $message ?: sprintf(
+                        'Failed asserting that %s contains %s.',
+                        var_export( $haystack, true ),
+                        var_export( $needle, true )
+                    );
+
+                    $this->fail( $message );
+                }
+            }
+        }
+    }
+}
+
+namespace TCN\Platform\Auth {
+    if ( ! class_exists( PasswordLoginService::class, false ) ) {
+        class PasswordLoginService {
+            public const RATE_LIMIT_PREFIX = 'gn_login_rate_';
+            public const TOKEN_PREFIX      = 'gn_login_token_';
+            public const API_TOKEN_PREFIX  = 'tcn_api_tok_';
+            public const RESET_META_KEY    = '_gn_password_api_reset_code';
+        }
+    }
+}
+
+namespace {
+    if ( ! class_exists( 'WP_Error', false ) ) {
+        class WP_Error {
+            public function __construct( $code = '', $message = '', $data = array() ) {}
+        }
+    }
+
+    if ( ! class_exists( 'WP_REST_Request', false ) ) {
+        class WP_REST_Request {
+            /**
+             * @var array<string, string>
+             */
+            private $headers = array();
+
+            public function __construct( array $headers = array() ) {
+                foreach ( $headers as $key => $value ) {
+                    $this->headers[ strtolower( (string) $key ) ] = (string) $value;
+                }
+            }
+
+            public function get_header( $key ) {
+                $key = strtolower( (string) $key );
+
+                return $this->headers[ $key ] ?? '';
+            }
+        }
+    }
+
+    if ( ! function_exists( 'wp_unslash' ) ) {
+        function wp_unslash( $value ) {
+            return $value;
+        }
+    }
+
+    if ( ! function_exists( '__' ) ) {
+        function __( $text ) {
+            return $text;
+        }
+    }
+
+    if ( ! function_exists( 'rest_authorization_required_code' ) ) {
+        function rest_authorization_required_code() {
+            return 401;
+        }
+    }
+
+    if ( ! function_exists( 'get_user_by' ) ) {
+        function get_user_by( $field, $value ) {
+            if ( 'id' === strtolower( (string) $field ) && 123 === (int) $value ) {
+                return (object) array( 'ID' => 123 );
+            }
+
+            return false;
+        }
+    }
+
+    if ( ! function_exists( 'wp_set_current_user' ) ) {
+        function wp_set_current_user( $user_id ) {
+            $GLOBALS['current_user_id'] = (int) $user_id;
+        }
+    }
+
+    require_once __DIR__ . '/../vendor/autoload.php';
+    require_once __DIR__ . '/../includes/Auth/TokenAuthenticator.php';
+}

--- a/tests/run.php
+++ b/tests/run.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/bootstrap.php';
+require __DIR__ . '/TokenAuthenticatorTest.php';
+
+$test_class = 'TokenAuthenticatorTest';
+
+if ( ! class_exists( $test_class ) ) {
+    fwrite( STDERR, "Test class {$test_class} not found.\n" );
+    exit( 1 );
+}
+
+$methods = array_filter(
+    get_class_methods( $test_class ),
+    static function ( string $method ): bool {
+        return 0 === strpos( $method, 'test_' );
+    }
+);
+
+$failures = 0;
+
+foreach ( $methods as $method ) {
+    $test_instance = new $test_class();
+
+    try {
+        $test_instance->runTestMethod( $method );
+        fwrite( STDOUT, sprintf( "✔ %s\n", $method ) );
+    } catch ( PHPUnit\Framework\AssertionFailedError $e ) {
+        fwrite( STDERR, sprintf( "✘ %s: %s\n", $method, $e->getMessage() ) );
+        $failures++;
+    } catch ( Throwable $e ) {
+        fwrite( STDERR, sprintf( "✘ %s: %s\n", $method, $e->getMessage() ) );
+        $failures++;
+    }
+}
+
+if ( $failures > 0 ) {
+    exit( 1 );
+}
+
+echo "All tests passed.\n";


### PR DESCRIPTION
## Summary
- extend the token authenticator to read authorization headers from REDIRECT_HTTP_AUTHORIZATION and AUTHORIZATION when the main header is missing
- add a lightweight test harness with coverage for the new fallbacks
- bump the plugin version to 0.3.51 and document the release notes

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68e2a409b3788327aecc3f5714e30120