### PR TITLE
Add deployment checklists admin page

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ These settings persist in the `gn_login_api_settings` option. A compatibility sh
 - The log captures calls to `gn/v1/*` and `tcn-mlm/v1/*` namespaces, redacting sensitive payload fields like passwords and tokens.
 - Activation, deactivation, settings changes, and manual log clears are also recorded so administrators can audit configuration changes.
 
+## 🧾 Deployment Checklists
+
+- Head to **TCN Platform → Deployment Checklists** for a curated set of preflight checks and troubleshooting tips covering the Password Login API routes.
+- Each section summarises endpoint verification, HTTPS and CORS settings, bearer token expectations, avatar upload requirements, and cURL recipes you can run directly from the server.
+- Quick “App” and “Plugin/Server” lists make it easy to confirm both sides of the integration before shipping builds to QA or production.
+
 ## 💼 Membership & MLM Highlights
 
 - Seeds Blue/Gold/Platinum/Black WooCommerce products on activation, maintaining pricing alignment with the mobile catalogue.
@@ -97,6 +103,10 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 - Namespaced PHP classes live under `includes/` and autoload via `includes/Autoloader.php`.
 
 ## 📝 Release Notes
+
+### 0.3.53
+- Add a Deployment Checklists admin page that consolidates endpoint verification steps, HTTPS/CORS guidance, REST payload expectations, and server-side cURL examples for `/gn/v1/login`, `/gn/v1/change-password`, and `/gn/v1/profile/avatar`.
+- Style the new panel alongside existing admin screens so troubleshooting guides are easy to read directly inside WordPress.
 
 ### 0.3.52
 - Ensure `/change-password` resolves the authenticated user when requests rely solely on `Authorization: Bearer` tokens so mobile clients can rotate credentials without a browser cookie.

--- a/admin/css/tcn-platform-admin.css
+++ b/admin/css/tcn-platform-admin.css
@@ -1,6 +1,7 @@
 .tcn-platform-settings,
 .tcn-platform-api-tester,
-.tcn-platform-logs {
+.tcn-platform-logs,
+.tcn-platform-checklists {
     --tcn-primary: #2563eb;
     --tcn-primary-dark: #1d4ed8;
     --tcn-surface: #ffffff;
@@ -16,7 +17,8 @@
 
 .wrap.tcn-platform-settings,
 .wrap.tcn-platform-api-tester,
-.wrap.tcn-platform-logs {
+.wrap.tcn-platform-logs,
+.wrap.tcn-platform-checklists {
     position: relative;
     width: 100%;
     max-width: 1080px;
@@ -27,7 +29,8 @@
     box-shadow: var(--tcn-shadow-soft);
 }
 
-.wrap.tcn-platform-logs {
+.wrap.tcn-platform-logs,
+.wrap.tcn-platform-checklists {
     max-width: 1480px;
 }
 
@@ -168,6 +171,66 @@
     margin-top: 8px;
     font-size: 13px;
     color: var(--tcn-text-muted);
+}
+
+.tcn-platform-checklist-content p,
+.tcn-platform-checklist-content ul,
+.tcn-platform-checklist-content ol,
+.tcn-platform-checklist-content pre {
+    margin-bottom: 16px;
+}
+
+.tcn-platform-checklist-content ul {
+    padding-left: 20px;
+    list-style: disc;
+}
+
+.tcn-platform-checklist-content h3 {
+    margin: 20px 0 10px;
+    font-size: 16px;
+}
+
+.tcn-platform-checklist-content code {
+    padding: 2px 6px;
+    border-radius: 6px;
+    background: rgba(37, 99, 235, 0.12);
+    font-family: Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+}
+
+.tcn-platform-checklist-content pre {
+    padding: 16px;
+    border-radius: 12px;
+    background: var(--tcn-surface-muted);
+    border: 1px solid rgba(37, 99, 235, 0.15);
+    font-family: Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+    font-size: 13px;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.tcn-platform-checklist-grid {
+    display: grid;
+    gap: 20px;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.tcn-platform-checklist-panel {
+    padding: 20px;
+    border-radius: 14px;
+    background: var(--tcn-surface-muted);
+    border: 1px solid rgba(37, 99, 235, 0.18);
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+}
+
+.tcn-platform-checklist-panel h3 {
+    margin-top: 0;
+    margin-bottom: 14px;
+}
+
+.tcn-platform-checklist-panel ul {
+    margin: 0;
+    padding-left: 20px;
+    list-style: disc;
 }
 
 .tcn-platform-actions {

--- a/includes/Admin/ChecklistPage.php
+++ b/includes/Admin/ChecklistPage.php
@@ -1,0 +1,236 @@
+<?php
+namespace TCN\Platform\Admin;
+
+use function __;
+use function add_action;
+use function add_submenu_page;
+use function current_user_can;
+use function esc_html__;
+use function esc_html_e;
+use function wp_die;
+
+class ChecklistPage {
+    public function register(): void {
+        add_action( 'admin_menu', array( $this, 'register_menu' ) );
+    }
+
+    public function register_menu(): void {
+        add_submenu_page(
+            'tcn-platform',
+            __( 'Deployment Checklists', 'tcnapp-connector' ),
+            __( 'Deployment Checklists', 'tcnapp-connector' ),
+            'manage_options',
+            'tcn-platform-checklists',
+            array( $this, 'render_page' )
+        );
+    }
+
+    public function render_page(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'You do not have permission to access this page.', 'tcnapp-connector' ) );
+        }
+
+        $change_password_payload = <<<'JSON'
+{
+  "current_password": "oldPass123",
+  "password": "newPass456"
+}
+JSON;
+
+        $curl_examples = array(
+            'login'           => implode(
+                "\n",
+                array(
+                    "curl -X POST \"{BASE_URL}/wp-json/gn/v1/login\" \\",
+                    "  -H \"Content-Type: application/json\" \\",
+                    "  -d '{\"username\":\"YOUR_USER\",\"password\":\"YOUR_PASS\"}'",
+                )
+            ),
+            'change_password' => implode(
+                "\n",
+                array(
+                    "curl -X POST \"{BASE_URL}/wp-json/gn/v1/change-password\" \\",
+                    "  -H \"Authorization: Bearer YOUR_TOKEN\" \\",
+                    "  -H \"Content-Type: application/json\" \\",
+                    "  -d '{\"current_password\":\"oldPass123\",\"password\":\"newPass456\"}'",
+                )
+            ),
+            'upload_avatar'   => implode(
+                "\n",
+                array(
+                    "curl -X POST \"{BASE_URL}/wp-json/gn/v1/profile/avatar\" \\",
+                    "  -H \"Authorization: Bearer YOUR_TOKEN\" \\",
+                    "  -F \"avatar=@/full/path/to/photo.jpg\"",
+                )
+            ),
+        );
+
+        ?>
+        <div class="wrap tcn-platform-checklists">
+            <div class="tcn-platform-page-intro">
+                <h1><?php esc_html_e( 'TCN Platform Deployment Checklists', 'tcnapp-connector' ); ?></h1>
+                <p class="description tcn-platform-page-subtitle">
+                    <?php esc_html_e( 'Use these quick guides to validate the password login API, tighten transport security, and troubleshoot the mobile app integration.', 'tcnapp-connector' ); ?>
+                </p>
+            </div>
+
+            <section id="tcn-checklist-b1" class="tcn-platform-section">
+                <div class="tcn-platform-section-header">
+                    <h2><?php esc_html_e( 'B1) Verify Endpoints Exist', 'tcnapp-connector' ); ?></h2>
+                    <p class="description"><?php esc_html_e( 'Confirm the REST API routes respond before pointing clients at the site.', 'tcnapp-connector' ); ?></p>
+                </div>
+                <div class="tcn-platform-checklist-content">
+                    <p><?php esc_html_e( 'Open WP Admin → Tools → Site Health → REST API or send manual HTTP requests and make sure the following endpoints are registered:', 'tcnapp-connector' ); ?></p>
+                    <ul>
+                        <li><code>POST /wp-json/gn/v1/login</code></li>
+                        <li><code>POST /wp-json/gn/v1/change-password</code></li>
+                        <li><code>POST /wp-json/gn/v1/profile/avatar</code></li>
+                    </ul>
+                    <p><?php esc_html_e( 'If any /gn/v1 route returns a 404, flush permalinks by visiting WP Admin → Settings → Permalinks and clicking Save without changing the structure.', 'tcnapp-connector' ); ?></p>
+                </div>
+            </section>
+
+            <section id="tcn-checklist-b2" class="tcn-platform-section">
+                <div class="tcn-platform-section-header">
+                    <h2><?php esc_html_e( 'B2) Security & Transport Settings', 'tcnapp-connector' ); ?></h2>
+                    <p class="description"><?php esc_html_e( 'Review HTTPS, CORS, and rate limiting controls in TCN Platform → Settings.', 'tcnapp-connector' ); ?></p>
+                </div>
+                <div class="tcn-platform-checklist-content">
+                    <h3><?php esc_html_e( 'HTTPS Enforcement', 'tcnapp-connector' ); ?></h3>
+                    <ul>
+                        <li><?php esc_html_e( 'Production sites should leave “Allow HTTP During Development” disabled so HTTPS remains required.', 'tcnapp-connector' ); ?></li>
+                        <li><?php esc_html_e( 'Development sites running over HTTP can temporarily enable “Allow HTTP During Development”. This requires WP_DEBUG to be true and should never be enabled in production.', 'tcnapp-connector' ); ?></li>
+                    </ul>
+
+                    <h3><?php esc_html_e( 'Allowed Origin (CORS)', 'tcnapp-connector' ); ?></h3>
+                    <p><?php esc_html_e( 'Set a precise origin when the mobile app runs in a browser or hybrid shell (for example, http://localhost:19006 or https://app.example.com). Leaving the field blank reflects the incoming Origin header but some browsers enforce an explicit value.', 'tcnapp-connector' ); ?></p>
+
+                    <h3><?php esc_html_e( 'Token Lifetime & Rate Limits', 'tcnapp-connector' ); ?></h3>
+                    <p><?php esc_html_e( 'Token TTL and rate limits can stay on their defaults in production. If developers encounter frequent expiries in testing, extend the lifetime temporarily while debugging.', 'tcnapp-connector' ); ?></p>
+                </div>
+            </section>
+
+            <section id="tcn-checklist-b3" class="tcn-platform-section">
+                <div class="tcn-platform-section-header">
+                    <h2><?php esc_html_e( 'B3) Authentication', 'tcnapp-connector' ); ?></h2>
+                    <p class="description"><?php esc_html_e( 'Understand how bearer tokens secure the protected routes.', 'tcnapp-connector' ); ?></p>
+                </div>
+                <div class="tcn-platform-checklist-content">
+                    <ul>
+                        <li><?php esc_html_e( 'Protected endpoints expect an Authorization: Bearer token unless labelled public.', 'tcnapp-connector' ); ?></li>
+                        <li><?php esc_html_e( 'Retrieve tokens from POST /wp-json/gn/v1/login using a valid WordPress username and password.', 'tcnapp-connector' ); ?></li>
+                        <li><?php esc_html_e( 'Ensure the authenticated user account is active and not blocked by membership or capability plugins.', 'tcnapp-connector' ); ?></li>
+                        <li><?php esc_html_e( 'If the site is behind Cloudflare or another proxy, confirm Authorization headers reach PHP unchanged.', 'tcnapp-connector' ); ?></li>
+                    </ul>
+                </div>
+            </section>
+
+            <section id="tcn-checklist-b4" class="tcn-platform-section">
+                <div class="tcn-platform-section-header">
+                    <h2><?php esc_html_e( 'B4) Change Password — Server Expectations', 'tcnapp-connector' ); ?></h2>
+                    <p class="description"><?php esc_html_e( 'Validate payloads and server-side checks for password rotations.', 'tcnapp-connector' ); ?></p>
+                </div>
+                <div class="tcn-platform-checklist-content">
+                    <p><?php esc_html_e( 'Route: POST /wp-json/gn/v1/change-password (Authorization: Bearer required). Send JSON in the following shape:', 'tcnapp-connector' ); ?></p>
+                    <pre><code><?php echo esc_html( $change_password_payload ); ?></code></pre>
+                    <p><?php esc_html_e( 'Typical validations include confirming the token maps to the current user, verifying the existing password, enforcing password policy, updating the credential, and optionally revoking older tokens.', 'tcnapp-connector' ); ?></p>
+                    <p><?php esc_html_e( 'Common error responses: unauthorized or missing token, invalid current password, https_required, or rate_limited.', 'tcnapp-connector' ); ?></p>
+                </div>
+            </section>
+
+            <section id="tcn-checklist-b5" class="tcn-platform-section">
+                <div class="tcn-platform-section-header">
+                    <h2><?php esc_html_e( 'B5) Change Profile Picture (Avatar) — Server Expectations', 'tcnapp-connector' ); ?></h2>
+                    <p class="description"><?php esc_html_e( 'Ensure the upload workflow matches the REST endpoint requirements.', 'tcnapp-connector' ); ?></p>
+                </div>
+                <div class="tcn-platform-checklist-content">
+                    <p><?php esc_html_e( 'Route: POST /wp-json/gn/v1/profile/avatar (Authorization: Bearer required). Submit multipart/form-data with an avatar file.', 'tcnapp-connector' ); ?></p>
+                    <ul>
+                        <li><?php esc_html_e( 'Validate the authenticated user from the token.', 'tcnapp-connector' ); ?></li>
+                        <li><?php esc_html_e( 'Check file type and size (JPEG, PNG, or WEBP are typical).', 'tcnapp-connector' ); ?></li>
+                        <li><?php esc_html_e( 'Store the file with wp_handle_upload or media_sideload_image and update user meta for avatar mappings.', 'tcnapp-connector' ); ?></li>
+                        <li><?php esc_html_e( 'Return success JSON containing the refreshed avatar URLs.', 'tcnapp-connector' ); ?></li>
+                    </ul>
+                    <p><?php esc_html_e( 'The server rejects requests without an avatar field, with JSON bodies instead of multipart payloads, with oversized or disallowed files, or when the user is not authenticated.', 'tcnapp-connector' ); ?></p>
+                </div>
+            </section>
+
+            <section id="tcn-checklist-b6" class="tcn-platform-section">
+                <div class="tcn-platform-section-header">
+                    <h2><?php esc_html_e( 'B6) Logs & Where to Debug', 'tcnapp-connector' ); ?></h2>
+                    <p class="description"><?php esc_html_e( 'Check the activity log and server logs whenever a REST request fails.', 'tcnapp-connector' ); ?></p>
+                </div>
+                <div class="tcn-platform-checklist-content">
+                    <p><?php esc_html_e( 'Navigate to WP Admin → TCN Platform → Activity Log to review recent REST requests. Expect entries for permissions_check failures, missing avatar files, HTTPS enforcement blocks, or CORS issues.', 'tcnapp-connector' ); ?></p>
+                    <p><?php esc_html_e( 'Also inspect wp-content/debug.log (with WP_DEBUG_LOG enabled), web server logs, and any security plugin logs when troubleshooting.', 'tcnapp-connector' ); ?></p>
+                </div>
+            </section>
+
+            <section id="tcn-checklist-b7" class="tcn-platform-section">
+                <div class="tcn-platform-section-header">
+                    <h2><?php esc_html_e( 'B7) Quick Server-Side Self-Tests', 'tcnapp-connector' ); ?></h2>
+                    <p class="description"><?php esc_html_e( 'Use curl or an API client to validate critical flows directly from the server.', 'tcnapp-connector' ); ?></p>
+                </div>
+                <div class="tcn-platform-checklist-content">
+                    <p><?php esc_html_e( '1) Login and copy the bearer token:', 'tcnapp-connector' ); ?></p>
+                    <pre><code><?php echo esc_html( $curl_examples['login'] ); ?></code></pre>
+                    <p><?php esc_html_e( '2) Change the password with the issued token:', 'tcnapp-connector' ); ?></p>
+                    <pre><code><?php echo esc_html( $curl_examples['change_password'] ); ?></code></pre>
+                    <p><?php esc_html_e( '3) Upload an avatar image:', 'tcnapp-connector' ); ?></p>
+                    <pre><code><?php echo esc_html( $curl_examples['upload_avatar'] ); ?></code></pre>
+                </div>
+            </section>
+
+            <section id="tcn-checklist-b8" class="tcn-platform-section">
+                <div class="tcn-platform-section-header">
+                    <h2><?php esc_html_e( 'B8) Common Failure Matrix (Cause → Fix)', 'tcnapp-connector' ); ?></h2>
+                    <p class="description"><?php esc_html_e( 'Match frequent errors to the quickest resolution.', 'tcnapp-connector' ); ?></p>
+                </div>
+                <div class="tcn-platform-checklist-content">
+                    <ul>
+                        <li><strong><?php esc_html_e( '401 Unauthorized:', 'tcnapp-connector' ); ?></strong> <?php esc_html_e( 'Acquire a fresh token and ensure Authorization headers survive any proxy or CDN.', 'tcnapp-connector' ); ?></li>
+                        <li><strong><?php esc_html_e( '426/400 HTTPS Required:', 'tcnapp-connector' ); ?></strong> <?php esc_html_e( 'Enable “Allow HTTP During Development” only on local sites or switch the environment to HTTPS.', 'tcnapp-connector' ); ?></li>
+                        <li><strong><?php esc_html_e( '400 Avatar Upload Errors:', 'tcnapp-connector' ); ?></strong> <?php esc_html_e( 'Send multipart/form-data with the avatar field, a filename, and a valid MIME type.', 'tcnapp-connector' ); ?></li>
+                        <li><strong><?php esc_html_e( 'Browser CORS Errors:', 'tcnapp-connector' ); ?></strong> <?php esc_html_e( 'Set the Allowed Origin exactly, confirm OPTIONS preflight succeeds, and avoid wildcard origins with credentials.', 'tcnapp-connector' ); ?></li>
+                        <li><strong><?php esc_html_e( '413 Payload Too Large:', 'tcnapp-connector' ); ?></strong> <?php esc_html_e( 'Increase PHP upload_max_filesize/post_max_size or compress the image before uploading.', 'tcnapp-connector' ); ?></li>
+                        <li><strong><?php esc_html_e( 'Capability or Role Restrictions:', 'tcnapp-connector' ); ?></strong> <?php esc_html_e( 'Verify the token resolves to the intended user and that the plugin allows that role to update avatars.', 'tcnapp-connector' ); ?></li>
+                    </ul>
+                </div>
+            </section>
+
+            <section id="tcn-checklist-c" class="tcn-platform-section">
+                <div class="tcn-platform-section-header">
+                    <h2><?php esc_html_e( 'C) Quick Checklists', 'tcnapp-connector' ); ?></h2>
+                    <p class="description"><?php esc_html_e( 'Run through these condensed lists when debugging either the client app or the server.', 'tcnapp-connector' ); ?></p>
+                </div>
+                <div class="tcn-platform-checklist-grid">
+                    <div class="tcn-platform-checklist-panel">
+                        <h3><?php esc_html_e( 'App Checklist', 'tcnapp-connector' ); ?></h3>
+                        <ul>
+                            <li><?php esc_html_e( 'Confirm BASE_URL targets the correct WordPress site.', 'tcnapp-connector' ); ?></li>
+                            <li><?php esc_html_e( 'Request and store a fresh token securely.', 'tcnapp-connector' ); ?></li>
+                            <li><?php esc_html_e( 'Send Authorization: Bearer <token> on protected calls.', 'tcnapp-connector' ); ?></li>
+                            <li><?php esc_html_e( 'Change Password requests include current_password and password in JSON.', 'tcnapp-connector' ); ?></li>
+                            <li><?php esc_html_e( 'Upload Avatar uses FormData with the avatar field, filename, and MIME type without manually forcing Content-Type.', 'tcnapp-connector' ); ?></li>
+                            <li><?php esc_html_e( 'Handle 401 responses by prompting for a new login.', 'tcnapp-connector' ); ?></li>
+                            <li><?php esc_html_e( 'Log full error responses (excluding secrets) for faster debugging.', 'tcnapp-connector' ); ?></li>
+                        </ul>
+                    </div>
+                    <div class="tcn-platform-checklist-panel">
+                        <h3><?php esc_html_e( 'Plugin / Server Checklist', 'tcnapp-connector' ); ?></h3>
+                        <ul>
+                            <li><?php esc_html_e( 'Verify /gn/v1/login, /gn/v1/change-password, and /gn/v1/profile/avatar are registered.', 'tcnapp-connector' ); ?></li>
+                            <li><?php esc_html_e( 'Enforce HTTPS in production and reserve “Allow HTTP During Development” for local environments.', 'tcnapp-connector' ); ?></li>
+                            <li><?php esc_html_e( 'Set the Allowed Origin to the exact app origin when applicable.', 'tcnapp-connector' ); ?></li>
+                            <li><?php esc_html_e( 'Confirm proxies preserve Authorization headers.', 'tcnapp-connector' ); ?></li>
+                            <li><?php esc_html_e( 'Allow media uploads and size limits that accommodate avatar images.', 'tcnapp-connector' ); ?></li>
+                            <li><?php esc_html_e( 'Monitor the Activity Log and enable WP_DEBUG_LOG during development.', 'tcnapp-connector' ); ?></li>
+                            <li><?php esc_html_e( 'Flush permalinks if REST routes return 404 errors.', 'tcnapp-connector' ); ?></li>
+                        </ul>
+                    </div>
+                </div>
+            </section>
+        </div>
+        <?php
+    }
+}

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -3,6 +3,7 @@ namespace TCN\Platform;
 
 use TCN\Platform\Admin\Assets;
 use TCN\Platform\Admin\ApiTesterPage;
+use TCN\Platform\Admin\ChecklistPage;
 use TCN\Platform\Admin\LogPage;
 use TCN\Platform\Admin\SettingsPage;
 use TCN\Platform\Auth\PasswordLoginService;
@@ -72,6 +73,7 @@ class Plugin {
             $this->services[] = new SettingsPage( $this->modules );
             $this->services[] = new LogPage();
             $this->services[] = new ApiTesterPage();
+            $this->services[] = new ChecklistPage();
             $this->services[] = new Assets();
         }
     }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.52
+Stable tag: 0.3.53
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -93,6 +93,10 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.53 =
+* Feature: Introduce a Deployment Checklists screen under **TCN Platform** that guides administrators through verifying `/gn/v1/login`, `/gn/v1/change-password`, and `/gn/v1/profile/avatar`, tuning HTTPS/CORS, validating payloads, and running cURL smoke tests from the server.
+* Enhancement: Align the new troubleshooting cards with existing admin styling so the guidance is easy to scan inside WordPress.
+
 = 0.3.52 =
 * Fix: Ensure `/gn/v1/change-password` resolves the authenticated user when requests rely solely on `Authorization: Bearer` tokens so mobile clients can rotate credentials without needing browser cookies.
 * Enhancement: Refresh the API tester preset and documentation to highlight the bearer token requirement, payload fields, and multipart avatar upload expectations.

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.52
+ * Version:           0.3.53
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.52' );
+define( 'TCN_PLATFORM_VERSION', '0.3.53' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- add a Deployment Checklists admin screen that walks through REST endpoint verification, security settings, payload expectations, and troubleshooting for the gn/v1 routes
- update plugin assets and documentation to reference the new guidance and bump the release to 0.3.53

## Testing
- php -l includes/Admin/ChecklistPage.php

------
https://chatgpt.com/codex/tasks/task_e_68e2b39ed5088327957ad8556073cfc5