### PR TITLE
Rename dev HTTP toggle and refresh deployment checklist copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Toggle modules under **TCN Platform → Modules**. The Membership & MLM module s
 - WooCommerce 7.0+
 - PHP 7.4+
 - MySQL 5.7+ / MariaDB 10.3+
-- HTTPS (strongly recommended; REST login endpoints reject non-SSL requests unless `Allow HTTP During Development` is enabled while `WP_DEBUG` is true)
+- HTTPS (strongly recommended; REST login endpoints reject non-SSL requests unless `Allow Dev HTTP` is enabled while `WP_DEBUG` is true)
 
 ## 🚀 Installation
 
@@ -34,7 +34,7 @@ Toggle modules under **TCN Platform → Modules**. The Membership & MLM module s
 
 ### Password Login API Settings
 - **Allowed CORS Origin** – Exact origin (scheme + host + optional port) allowed to call `gn/v1` endpoints cross-origin. Leave blank to restrict to same-origin requests.
-- **Allow HTTP During Development** – Permits non-HTTPS requests when `WP_DEBUG` is true. Only enable for local development environments.
+- **Allow Dev HTTP** – Permits non-HTTPS requests when `WP_DEBUG` is true. Only enable for local development environments.
 
 These settings persist in the `gn_login_api_settings` option. A compatibility shim keeps `GN_Password_Login_API` usable for legacy code.
 
@@ -103,6 +103,10 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 - Namespaced PHP classes live under `includes/` and autoload via `includes/Autoloader.php`.
 
 ## 📝 Release Notes
+
+-### 0.3.54
+- Refresh the deployment checklist copy to match the latest HTTPS and CORS guidance, highlighting the “Allow Dev HTTP” toggle and explicit origin recommendations.
+- Rename the HTTPS development toggle in settings to “Allow Dev HTTP” so the UI and documentation use the same label.
 
 ### 0.3.53
 - Add a Deployment Checklists admin page that consolidates endpoint verification steps, HTTPS/CORS guidance, REST payload expectations, and server-side cURL examples for `/gn/v1/login`, `/gn/v1/change-password`, and `/gn/v1/profile/avatar`.

--- a/includes/Admin/ChecklistPage.php
+++ b/includes/Admin/ChecklistPage.php
@@ -98,12 +98,12 @@ JSON;
                 <div class="tcn-platform-checklist-content">
                     <h3><?php esc_html_e( 'HTTPS Enforcement', 'tcnapp-connector' ); ?></h3>
                     <ul>
-                        <li><?php esc_html_e( 'Production sites should leave “Allow HTTP During Development” disabled so HTTPS remains required.', 'tcnapp-connector' ); ?></li>
-                        <li><?php esc_html_e( 'Development sites running over HTTP can temporarily enable “Allow HTTP During Development”. This requires WP_DEBUG to be true and should never be enabled in production.', 'tcnapp-connector' ); ?></li>
+                        <li><?php esc_html_e( 'In production, keep HTTPS required (recommended).', 'tcnapp-connector' ); ?></li>
+                        <li><?php esc_html_e( 'In development, if the site runs on HTTP, enable “Allow Dev HTTP”. This typically only works when WP_DEBUG is true and should never be enabled in production.', 'tcnapp-connector' ); ?></li>
                     </ul>
 
                     <h3><?php esc_html_e( 'Allowed Origin (CORS)', 'tcnapp-connector' ); ?></h3>
-                    <p><?php esc_html_e( 'Set a precise origin when the mobile app runs in a browser or hybrid shell (for example, http://localhost:19006 or https://app.example.com). Leaving the field blank reflects the incoming Origin header but some browsers enforce an explicit value.', 'tcnapp-connector' ); ?></p>
+                    <p><?php esc_html_e( 'Set a precise origin when the app is web or hybrid based (for example, http://localhost:19006 or https://app.example.com). If left blank the plugin reflects the request Origin, but specifying an explicit value helps avoid strict browser CORS blocks.', 'tcnapp-connector' ); ?></p>
 
                     <h3><?php esc_html_e( 'Token Lifetime & Rate Limits', 'tcnapp-connector' ); ?></h3>
                     <p><?php esc_html_e( 'Token TTL and rate limits can stay on their defaults in production. If developers encounter frequent expiries in testing, extend the lifetime temporarily while debugging.', 'tcnapp-connector' ); ?></p>
@@ -189,7 +189,7 @@ JSON;
                 <div class="tcn-platform-checklist-content">
                     <ul>
                         <li><strong><?php esc_html_e( '401 Unauthorized:', 'tcnapp-connector' ); ?></strong> <?php esc_html_e( 'Acquire a fresh token and ensure Authorization headers survive any proxy or CDN.', 'tcnapp-connector' ); ?></li>
-                        <li><strong><?php esc_html_e( '426/400 HTTPS Required:', 'tcnapp-connector' ); ?></strong> <?php esc_html_e( 'Enable “Allow HTTP During Development” only on local sites or switch the environment to HTTPS.', 'tcnapp-connector' ); ?></li>
+                        <li><strong><?php esc_html_e( '426/400 HTTPS Required:', 'tcnapp-connector' ); ?></strong> <?php esc_html_e( 'Enable “Allow Dev HTTP” only on local sites or switch the environment to HTTPS.', 'tcnapp-connector' ); ?></li>
                         <li><strong><?php esc_html_e( '400 Avatar Upload Errors:', 'tcnapp-connector' ); ?></strong> <?php esc_html_e( 'Send multipart/form-data with the avatar field, a filename, and a valid MIME type.', 'tcnapp-connector' ); ?></li>
                         <li><strong><?php esc_html_e( 'Browser CORS Errors:', 'tcnapp-connector' ); ?></strong> <?php esc_html_e( 'Set the Allowed Origin exactly, confirm OPTIONS preflight succeeds, and avoid wildcard origins with credentials.', 'tcnapp-connector' ); ?></li>
                         <li><strong><?php esc_html_e( '413 Payload Too Large:', 'tcnapp-connector' ); ?></strong> <?php esc_html_e( 'Increase PHP upload_max_filesize/post_max_size or compress the image before uploading.', 'tcnapp-connector' ); ?></li>
@@ -220,7 +220,7 @@ JSON;
                         <h3><?php esc_html_e( 'Plugin / Server Checklist', 'tcnapp-connector' ); ?></h3>
                         <ul>
                             <li><?php esc_html_e( 'Verify /gn/v1/login, /gn/v1/change-password, and /gn/v1/profile/avatar are registered.', 'tcnapp-connector' ); ?></li>
-                            <li><?php esc_html_e( 'Enforce HTTPS in production and reserve “Allow HTTP During Development” for local environments.', 'tcnapp-connector' ); ?></li>
+                            <li><?php esc_html_e( 'Enforce HTTPS in production and reserve “Allow Dev HTTP” for local environments.', 'tcnapp-connector' ); ?></li>
                             <li><?php esc_html_e( 'Set the Allowed Origin to the exact app origin when applicable.', 'tcnapp-connector' ); ?></li>
                             <li><?php esc_html_e( 'Confirm proxies preserve Authorization headers.', 'tcnapp-connector' ); ?></li>
                             <li><?php esc_html_e( 'Allow media uploads and size limits that accommodate avatar images.', 'tcnapp-connector' ); ?></li>

--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -164,7 +164,7 @@ class SettingsPage {
                             </tr>
                             <tr>
                                 <th scope="row">
-                                    <label for="allow_dev_http"><?php esc_html_e( 'Allow HTTP During Development', 'tcnapp-connector' ); ?></label>
+                                    <label for="allow_dev_http"><?php esc_html_e( 'Allow Dev HTTP', 'tcnapp-connector' ); ?></label>
                                 </th>
                                 <td>
                                     <label>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.53
+Stable tag: 0.3.54
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -16,7 +16,7 @@ TCN Platform unifies the WooCommerce membership/MLM engine and the GN Password L
 * WooCommerce 7.0 or later
 * PHP 7.4 or later
 * MySQL 5.7 / MariaDB 10.3 or later
-* HTTPS (strongly recommended; REST login endpoints reject non-SSL requests unless "Allow HTTP During Development" is enabled while `WP_DEBUG` is true)
+* HTTPS (strongly recommended; REST login endpoints reject non-SSL requests unless "Allow Dev HTTP" is enabled while `WP_DEBUG` is true)
 
 === Modules ===
 * **Membership & MLM (always on)** – Seeds and syncs Blue/Gold/Platinum/Black membership products, manages genealogy, promotes members based on network rules, tracks commissions, exposes `tcn-mlm/v1/*` REST endpoints, and injects dashboards into WooCommerce My Account.
@@ -37,7 +37,7 @@ Configure modules under **TCN Platform → Modules**. The Membership & MLM modul
 
 === Password Login API Settings ===
 * **Allowed CORS Origin** – Exact origin permitted to post to `gn/v1` endpoints. Leave blank to restrict to same-origin calls.
-* **Allow HTTP During Development** – Permits non-HTTPS requests when `WP_DEBUG` is true; use only on local environments. You can further customise HTTPS behaviour via the `gn_password_api_allow_dev_http` filter.
+* **Allow Dev HTTP** – Permits non-HTTPS requests when `WP_DEBUG` is true; use only on local environments. You can further customise HTTPS behaviour via the `gn_password_api_allow_dev_http` filter.
 
 == Activity Monitoring ==
 * Monitor REST activity and plugin events from **TCN Platform → Activity Log** in the WordPress admin.
@@ -93,6 +93,10 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.54 =
+* Refresh the deployment checklist language so HTTPS, CORS, and troubleshooting guidance reference the “Allow Dev HTTP” toggle and explicit origin recommendations.
+* Rename the HTTPS development toggle in settings to “Allow Dev HTTP” for consistency with the documentation.
+
 = 0.3.53 =
 * Feature: Introduce a Deployment Checklists screen under **TCN Platform** that guides administrators through verifying `/gn/v1/login`, `/gn/v1/change-password`, and `/gn/v1/profile/avatar`, tuning HTTPS/CORS, validating payloads, and running cURL smoke tests from the server.
 * Enhancement: Align the new troubleshooting cards with existing admin styling so the guidance is easy to scan inside WordPress.

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.53
+ * Version:           0.3.54
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.53' );
+define( 'TCN_PLATFORM_VERSION', '0.3.54' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- rename the HTTPS development toggle to “Allow Dev HTTP” so the settings UI and documentation use the same wording
- refresh the deployment checklist guidance to align with the latest HTTPS/CORS instructions and rename relevant references
- bump the plugin version to 0.3.54 and update the accompanying documentation and changelog entries

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68e2b89006b4832794c59c542bc1cea8