### PR TITLE
Update deployment authentication checklist and bump version 0.3.55

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ These settings persist in the `gn_login_api_settings` option. A compatibility sh
 
 - Head to **TCN Platform → Deployment Checklists** for a curated set of preflight checks and troubleshooting tips covering the Password Login API routes.
 - Each section summarises endpoint verification, HTTPS and CORS settings, bearer token expectations, avatar upload requirements, and cURL recipes you can run directly from the server.
+- Authentication quick hits captured on the checklist keep the mobile app and server aligned:
+  - Protected endpoints expect an `Authorization: Bearer` token unless the route explicitly calls itself public.
+  - Retrieve bearer tokens from `POST /wp-json/gn/v1/login` with a valid WordPress username and password.
+  - Ensure the authenticated account stays active and is not blocked by membership or capability plugins before issuing tokens.
+  - When Cloudflare or another proxy sits in front of the site, verify the `Authorization` header survives to PHP unchanged.
 - Quick “App” and “Plugin/Server” lists make it easy to confirm both sides of the integration before shipping builds to QA or production.
 
 ## 💼 Membership & MLM Highlights
@@ -104,7 +109,10 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
--### 0.3.54
+### 0.3.55
+- Expand the deployment checklist authentication guidance to reinforce bearer token expectations, token retrieval, account status checks, and proxy header forwarding.
+
+### 0.3.54
 - Refresh the deployment checklist copy to match the latest HTTPS and CORS guidance, highlighting the “Allow Dev HTTP” toggle and explicit origin recommendations.
 - Rename the HTTPS development toggle in settings to “Allow Dev HTTP” so the UI and documentation use the same label.
 

--- a/docs/TCN_PLATFORM_REFERENCE.md
+++ b/docs/TCN_PLATFORM_REFERENCE.md
@@ -45,6 +45,13 @@ Every endpoint listed below has a matching preset in the tester, so you can vali
 - Errors return `WP_Error` objects with HTTP status codes (400, 401, 403, 404, 409, 429) depending on validation failures or rate limiting.
 - When `WOOCOMMERCE_CONSUMER_KEY` and `WOOCOMMERCE_CONSUMER_SECRET` constants are defined, successful responses include an `auth.woocommerce` bundle (plus the same data on the `user.woocommerce` key) exposing the consumer pair and ready-to-use Basic authorization header for subsequent bridge requests.
 
+**Authentication checklist**
+
+- Protected endpoints require an `Authorization: Bearer` token unless the route explicitly declares itself public.
+- Always retrieve fresh bearer tokens from `POST /wp-json/gn/v1/login` with a valid WordPress username/email and password before calling protected routes.
+- Confirm the authenticated account remains active and isn’t blocked by membership or capability plugins that would prevent logins or avatar uploads.
+- If Cloudflare or any proxy/CDN fronts the site, verify the `Authorization` header survives to PHP unchanged (check `$_SERVER['HTTP_AUTHORIZATION']` and related FastCGI vars).
+
 #### WordPress Avatar Upload Endpoint
 
 The mobile app now calls `POST /wp-json/gn/v1/profile/avatar` to upload a member's profile photo. The endpoint is expected to accept a `multipart/form-data` payload with an `avatar` field that contains the uploaded image file. A successful response must return the updated user profile in the same shape as `/wp-json/wp/v2/users/me` so the client can refresh the cached session.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.54
+Stable tag: 0.3.55
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -43,6 +43,14 @@ Configure modules under **TCN Platform → Modules**. The Membership & MLM modul
 * Monitor REST activity and plugin events from **TCN Platform → Activity Log** in the WordPress admin.
 * The log records calls to `gn/v1/*` and `tcn-mlm/v1/*`, automatically redacting sensitive payload fields such as passwords and tokens.
 * Plugin activation, deactivation, module toggles, settings updates, and manual log clears also appear so administrators can audit configuration changes.
+
+== Deployment Checklists ==
+* Visit **TCN Platform → Deployment Checklists** for preflight checks covering the Password Login API routes.
+* Authentication quick hits called out on the page:
+  * Protected endpoints expect an `Authorization: Bearer` token unless the route explicitly states it is public.
+  * Retrieve bearer tokens from `POST /wp-json/gn/v1/login` with a valid WordPress username/email and password.
+  * Confirm the authenticated account is active and not blocked by membership or capability plugins before testing protected routes.
+  * When Cloudflare or other proxies sit in front of the site, verify the `Authorization` header reaches PHP unchanged.
 
 == Membership & MLM Highlights ==
 * Seed Blue/Gold/Platinum/Black WooCommerce products on activation so the catalogue aligns with the mobile tiers.
@@ -93,6 +101,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.55 =
+* Update the deployment checklist authentication guidance to emphasise bearer token requirements, token retrieval, account status checks, and proxy header forwarding.
+
 = 0.3.54 =
 * Refresh the deployment checklist language so HTTPS, CORS, and troubleshooting guidance reference the “Allow Dev HTTP” toggle and explicit origin recommendations.
 * Rename the HTTPS development toggle in settings to “Allow Dev HTTP” for consistency with the documentation.

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.54
+ * Version:           0.3.55
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.54' );
+define( 'TCN_PLATFORM_VERSION', '0.3.55' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- highlight bearer token expectations, login token retrieval, account status checks, and proxy header forwarding in the deployment checklist documentation
- extend the authentication guidance across the README, WordPress readme, and reference guide
- bump the plugin version to 0.3.55

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2ba740bc08327af58b3efacf0164f