### PR TITLE
Enable bearer token authentication for REST requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.56
+- Automatically authenticate REST requests that supply bearer tokens so protected endpoints recognise the same API tokens issued by `/gn/v1/login`, including WooCommerce customer and order routes.
+
 ### 0.3.55
 - Expand the deployment checklist authentication guidance to reinforce bearer token expectations, token retrieval, account status checks, and proxy header forwarding.
 

--- a/includes/Auth/TokenAuthenticator.php
+++ b/includes/Auth/TokenAuthenticator.php
@@ -11,39 +11,136 @@ class TokenAuthenticator {
      * @return int|WP_Error Returns the authenticated user ID on success, 0 when no token is present, or WP_Error for invalid tokens.
      */
     public function authenticate_request( WP_REST_Request $request ) {
-        $header = $request->get_header( 'authorization' );
-
-        $server_keys = array(
-            'HTTP_AUTHORIZATION',
-            'REDIRECT_HTTP_AUTHORIZATION',
-            'AUTHORIZATION',
-        );
+        $raw_header = $request->get_header( 'authorization' );
+        $header     = $this->resolve_authorization_header( $raw_header );
 
         $this->log_debug(
             'authenticate_request invoked',
             array(
-                'has_header'             => is_string( $header ) && '' !== trim( $header ),
+                'has_header'             => is_string( $raw_header ) && '' !== trim( $raw_header ),
                 'server_header_present'  => isset( $_SERVER['HTTP_AUTHORIZATION'] ),
                 'redirect_header_present' => isset( $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ),
                 'alt_header_present'      => isset( $_SERVER['AUTHORIZATION'] ),
             )
         );
 
-        if ( empty( $header ) ) {
-            foreach ( $server_keys as $server_key ) {
-                if ( isset( $_SERVER[ $server_key ] ) && '' !== trim( (string) $_SERVER[ $server_key ] ) ) {
-                    $header = (string) wp_unslash( $_SERVER[ $server_key ] );
-                    break;
-                }
-            }
-        }
-
-        if ( ! is_string( $header ) || '' === trim( $header ) ) {
+        if ( '' === $header ) {
             $this->log_debug( 'authenticate_request missing authorization header' );
 
             return 0;
         }
 
+        return $this->authenticate_with_header( $header );
+    }
+
+    /**
+     * Hook into WordPress authentication and honour bearer tokens for REST requests.
+     *
+     * @param int|false $user_id Current user ID resolved by WordPress.
+     * @return int|false
+     */
+    public function determine_current_user( $user_id ) {
+        if ( $user_id ) {
+            return $user_id;
+        }
+
+        if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) {
+            return $user_id;
+        }
+
+        $header = $this->resolve_authorization_header( '' );
+        if ( '' === $header ) {
+            return $user_id;
+        }
+
+        $token = $this->extract_token_from_header( $header );
+        if ( is_wp_error( $token ) ) {
+            return $user_id;
+        }
+
+        $result = $this->authenticate_with_token( $token );
+
+        if ( is_wp_error( $result ) || $result <= 0 ) {
+            return $user_id;
+        }
+
+        $this->log_debug(
+            'determine_current_user authenticated via bearer token',
+            array(
+                'user_id'    => $result,
+                'token_hash' => md5( $token ),
+            )
+        );
+
+        return $result;
+    }
+
+    /**
+     * Register WordPress hooks for automatic bearer token authentication.
+     */
+    public function register_hooks(): void {
+        add_filter( 'determine_current_user', array( $this, 'determine_current_user' ), 20 );
+    }
+
+    /**
+     * Retrieve the payload for a login hand-off token.
+     *
+     * @return array<string, mixed>|false
+     */
+    protected function get_login_token_payload( string $token_hash ) {
+        $payload = get_transient( PasswordLoginService::TOKEN_PREFIX . $token_hash );
+
+        if ( ! is_array( $payload ) || empty( $payload['user_id'] ) ) {
+            $this->log_debug(
+                'authenticate_request login token payload missing or expired',
+                array( 'token_hash' => $token_hash )
+            );
+
+            return false;
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Resolve an authorization header from the REST request or PHP globals.
+     */
+    protected function resolve_authorization_header( $header ): string {
+        if ( is_string( $header ) && '' !== trim( $header ) ) {
+            return trim( (string) $header );
+        }
+
+        foreach ( $this->get_server_header_keys() as $server_key ) {
+            if ( isset( $_SERVER[ $server_key ] ) && '' !== trim( (string) $_SERVER[ $server_key ] ) ) {
+                return trim( (string) wp_unslash( $_SERVER[ $server_key ] ) );
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Attempt to authenticate a request using a raw Authorization header value.
+     *
+     * @return int|WP_Error
+     */
+    protected function authenticate_with_header( string $header ) {
+        $token = $this->extract_token_from_header( $header );
+
+        if ( is_wp_error( $token ) ) {
+            return $token;
+        }
+
+        return $this->authenticate_with_token( $token );
+    }
+
+    /**
+     * Extract the bearer token from a header string.
+     *
+     * @param string $header Authorization header value.
+     * @return string|WP_Error
+     */
+    protected function extract_token_from_header( string $header ) {
         if ( ! preg_match( '/Bearer\s+(.*)$/i', $header, $matches ) ) {
             $this->log_debug(
                 'authenticate_request header missing bearer token prefix',
@@ -68,6 +165,16 @@ class TokenAuthenticator {
             );
         }
 
+        return $token;
+    }
+
+    /**
+     * Authenticate the resolved bearer token.
+     *
+     * @param string $token
+     * @return int|WP_Error
+     */
+    protected function authenticate_with_token( string $token ) {
         if ( ! class_exists( PasswordLoginService::class ) ) {
             $this->log_debug( 'authenticate_request PasswordLoginService class missing' );
 
@@ -128,23 +235,16 @@ class TokenAuthenticator {
     }
 
     /**
-     * Retrieve the payload for a login hand-off token.
+     * Return the list of server header keys to inspect for authorization values.
      *
-     * @return array<string, mixed>|false
+     * @return array<int, string>
      */
-    protected function get_login_token_payload( string $token_hash ) {
-        $payload = get_transient( PasswordLoginService::TOKEN_PREFIX . $token_hash );
-
-        if ( ! is_array( $payload ) || empty( $payload['user_id'] ) ) {
-            $this->log_debug(
-                'authenticate_request login token payload missing or expired',
-                array( 'token_hash' => $token_hash )
-            );
-
-            return false;
-        }
-
-        return $payload;
+    protected function get_server_header_keys(): array {
+        return array(
+            'HTTP_AUTHORIZATION',
+            'REDIRECT_HTTP_AUTHORIZATION',
+            'AUTHORIZATION',
+        );
     }
 
     /**

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -52,6 +52,7 @@ class Plugin {
 
     protected function register_services(): void {
         $token_authenticator = new TokenAuthenticator();
+        $token_authenticator->register_hooks();
 
         $this->services[] = new MembershipModule( $this->modules, $token_authenticator );
         $this->services[] = new ActivityMonitor();

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.55
+Stable tag: 0.3.56
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.56 =
+* Automatically authenticate REST requests that include bearer tokens so WooCommerce and other protected endpoints honour the Password Login API tokens issued by `/gn/v1/login`.
+
 = 0.3.55 =
 * Update the deployment checklist authentication guidance to emphasise bearer token requirements, token retrieval, account status checks, and proxy header forwarding.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.55
+ * Version:           0.3.56
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.55' );
+define( 'TCN_PLATFORM_VERSION', '0.3.56' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/tests/TokenAuthenticatorTest.php
+++ b/tests/TokenAuthenticatorTest.php
@@ -9,6 +9,10 @@ final class TokenAuthenticatorTest extends TestCase {
         parent::setUp();
         $_SERVER = array();
         unset( $GLOBALS['current_user_id'] );
+
+        if ( ! defined( 'REST_REQUEST' ) ) {
+            define( 'REST_REQUEST', true );
+        }
     }
 
     public function test_authenticates_with_redirect_header_fallback(): void {
@@ -63,6 +67,18 @@ final class TokenAuthenticatorTest extends TestCase {
         $result = $authenticator->authenticate_request( $request );
 
         $this->assertSame( 'WP_Error', get_class( $result ) );
+    }
+
+    public function test_determine_current_user_sets_user_from_bearer_token(): void {
+        $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer server-token';
+
+        $authenticator = $this->create_authenticator_expectation( 'server-token' );
+
+        $result = $authenticator->determine_current_user( 0 );
+
+        $this->assertSame( 123, $result );
+        $this->assertSame( 123, $GLOBALS['current_user_id'] ?? null );
+        $this->assertContains( md5( 'server-token' ), $authenticator->received_token_hashes );
     }
 
     private function create_authenticator_expectation( string $expected_token ): TokenAuthenticator {


### PR DESCRIPTION
## Summary
- hook the token authenticator into WordPress so REST requests with bearer tokens automatically authenticate and unlock protected endpoints
- extend the authenticator unit tests to cover determining the current user from global headers
- update the documentation and plugin metadata for version 0.3.56

## Testing
- not run (phpunit binary unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2d5a1458c832782868ea98d55f6aa