### PR TITLE
Suppress unnecessary TokenAuthenticator bearer prefix logs

### DIFF
--- a/includes/Auth/TokenAuthenticator.php
+++ b/includes/Auth/TokenAuthenticator.php
@@ -142,6 +142,14 @@ class TokenAuthenticator {
      */
     protected function extract_token_from_header( string $header ) {
         if ( ! preg_match( '/Bearer\s+(.*)$/i', $header, $matches ) ) {
+            if ( ! $this->should_log_non_bearer_header( $header ) ) {
+                return new WP_Error(
+                    'tcn_rest_invalid_token',
+                    __( 'The provided authentication token is invalid.', 'tcnapp-connector' ),
+                    array( 'status' => rest_authorization_required_code() )
+                );
+            }
+
             $this->log_debug(
                 'authenticate_request header missing bearer token prefix',
                 array( 'raw_header_preview' => $this->mask_string( $header ) )
@@ -166,6 +174,32 @@ class TokenAuthenticator {
         }
 
         return $token;
+    }
+
+    /**
+     * Determine whether a non-bearer Authorization header should be logged.
+     */
+    protected function should_log_non_bearer_header( string $header ): bool {
+        if ( '' === trim( $header ) ) {
+            return false;
+        }
+
+        if ( ! preg_match( '/^([A-Za-z]+)\s+/', $header, $matches ) ) {
+            return true;
+        }
+
+        $scheme = strtolower( (string) $matches[1] );
+
+        return ! in_array( $scheme, $this->get_suppressed_authorization_schemes(), true );
+    }
+
+    /**
+     * Return a list of Authorization schemes that should not trigger debug logs when missing a bearer token.
+     *
+     * @return array<int, string>
+     */
+    protected function get_suppressed_authorization_schemes(): array {
+        return array( 'basic', 'digest' );
     }
 
     /**

--- a/tests/TokenAuthenticatorTest.php
+++ b/tests/TokenAuthenticatorTest.php
@@ -67,6 +67,12 @@ final class TokenAuthenticatorTest extends TestCase {
         $result = $authenticator->authenticate_request( $request );
 
         $this->assertSame( 'WP_Error', get_class( $result ) );
+
+        foreach ( $authenticator->logged_messages as $log_entry ) {
+            if ( isset( $log_entry['message'] ) && 'authenticate_request header missing bearer token prefix' === $log_entry['message'] ) {
+                $this->fail( 'Expected Basic authorization header not to trigger bearer prefix debug log.' );
+            }
+        }
     }
 
     public function test_determine_current_user_sets_user_from_bearer_token(): void {
@@ -114,8 +120,13 @@ final class TokenAuthenticatorTest extends TestCase {
             }
 
             protected function log_debug( string $message, array $context = array() ): void {
-                // Silence debug output during tests.
+                $this->logged_messages[] = array(
+                    'message' => $message,
+                    'context' => $context,
+                );
             }
+
+            public $logged_messages = array();
         };
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -134,6 +134,12 @@ namespace {
         }
     }
 
+    if ( ! function_exists( 'is_wp_error' ) ) {
+        function is_wp_error( $thing ) {
+            return $thing instanceof WP_Error;
+        }
+    }
+
     require_once __DIR__ . '/../vendor/autoload.php';
     require_once __DIR__ . '/../includes/Auth/TokenAuthenticator.php';
 }


### PR DESCRIPTION
## Summary
- stop logging bearer prefix warnings for known non-bearer Authorization schemes
- extend TokenAuthenticator tests to cover the new behaviour and capture debug logs
- provide a simple is_wp_error shim in the bootstrap so the test harness can run standalone

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68e2dc7d69b48327a6e9b332ddfcfb97