### PR TITLE
Optimize WooCommerce product queries and release 0.3.58

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.58
+- Reduce memory usage when enumerating membership products by querying WooCommerce IDs and metadata on demand instead of instantiating every product object up front.
+
 ### 0.3.57
 - Automatically authenticate REST requests that supply bearer tokens so protected endpoints recognise the same API tokens issued by `/gn/v1/login`, including WooCommerce customer and order routes.
 

--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -506,28 +506,49 @@ class SettingsPage {
             $statuses = array( 'publish', 'pending', 'draft', 'private' );
         }
 
-        $products = \wc_get_products(
+        $product_ids = \wc_get_products(
             array(
                 'limit'   => -1,
                 'status'  => $statuses,
-                'return'  => 'objects',
+                'return'  => 'ids',
                 'orderby' => 'title',
                 'order'   => 'ASC',
             )
         );
 
-        if ( is_wp_error( $products ) ) {
-            $products = array();
+        if ( is_wp_error( $product_ids ) ) {
+            $product_ids = array();
         }
 
         $options = array();
 
-        foreach ( $products as $product ) {
-            $options[ $product->get_id() ] = sprintf(
+        foreach ( $product_ids as $product_id ) {
+            $product_id = (int) $product_id;
+
+            if ( $product_id <= 0 ) {
+                continue;
+            }
+
+            if ( 'product_variation' === get_post_type( $product_id ) ) {
+                continue;
+            }
+
+            $name = get_post_field( 'post_title', $product_id );
+
+            if ( '' === $name && function_exists( 'wc_get_product' ) ) {
+                $product = wc_get_product( $product_id );
+                $name    = $product ? $product->get_name() : '';
+            }
+
+            if ( '' === $name ) {
+                continue;
+            }
+
+            $options[ $product_id ] = sprintf(
                 /* translators: 1: WooCommerce product name, 2: product ID */
                 __( '%1$s (#%2$d)', 'tcnapp-connector' ),
-                $product->get_name(),
-                $product->get_id()
+                $name,
+                $product_id
             );
         }
 

--- a/includes/Support/Options.php
+++ b/includes/Support/Options.php
@@ -164,7 +164,7 @@ class Options {
             return $levels;
         }
 
-        $products = wc_get_products(
+        $product_ids = wc_get_products(
             array(
                 'limit'      => -1,
                 'status'     => array( 'publish', 'pending', 'draft' ),
@@ -174,15 +174,22 @@ class Options {
                         'compare' => 'EXISTS',
                     ),
                 ),
+                'return'     => 'ids',
             )
         );
 
-        if ( empty( $products ) ) {
+        if ( empty( $product_ids ) || is_wp_error( $product_ids ) ) {
             return $levels;
         }
 
-        foreach ( $products as $product ) {
-            $level_key = $product->get_meta( '_tcn_membership_level' );
+        foreach ( $product_ids as $product_id ) {
+            $product_id = (int) $product_id;
+
+            if ( $product_id <= 0 ) {
+                continue;
+            }
+
+            $level_key = get_post_meta( $product_id, '_tcn_membership_level', true );
 
             if ( ! is_string( $level_key ) ) {
                 continue;
@@ -194,14 +201,18 @@ class Options {
                 continue;
             }
 
-            $price = $product->get_meta( '_price', true );
+            $price = get_post_meta( $product_id, '_price', true );
 
             if ( '' === $price ) {
-                $price = $product->get_meta( '_regular_price', true );
+                $price = get_post_meta( $product_id, '_regular_price', true );
             }
 
             if ( '' === $price ) {
-                $price = $product->get_price( 'edit' );
+                $product = function_exists( 'wc_get_product' ) ? wc_get_product( $product_id ) : null;
+
+                if ( $product ) {
+                    $price = $product->get_price( 'edit' );
+                }
             }
 
             $levels[ $level_key ]['fee'] = self::parse_currency_amount( $price );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.57
+Stable tag: 0.3.58
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.58 =
+* Reduce memory usage when reading membership product data by loading WooCommerce product IDs and metadata on demand instead of instantiating every product object at once.
+
 = 0.3.57 =
 * Automatically authenticate REST requests that include bearer tokens so WooCommerce and other protected endpoints honour the Password Login API tokens issued by `/gn/v1/login`.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.57
+ * Version:           0.3.58
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.57' );
+define( 'TCN_PLATFORM_VERSION', '0.3.58' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- reduce memory usage when syncing membership product fees by querying WooCommerce product IDs and metadata on demand instead of hydrating every product object
- streamline the admin membership product selector to work from product IDs/titles and skip loading WooCommerce objects unnecessarily
- bump the plugin version to 0.3.58 and update release notes/changelog accordingly

## Testing
- php -l includes/Support/Options.php
- php -l includes/Admin/SettingsPage.php
- php -l tcnapp-connector.php

------
https://chatgpt.com/codex/tasks/task_e_68e2dfa2e8a08327b02fec39348eb0d8