### PR TITLE
Add JWT REST compatibility endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.59
+- Mirror the `jwt-auth/v1` REST endpoints from the standalone JWT Authentication plugin so existing clients can obtain, refresh, and validate JWTs without additional dependencies.
+
 ### 0.3.58
 - Reduce memory usage when enumerating membership products by querying WooCommerce IDs and metadata on demand instead of instantiating every product object up front.
 

--- a/docs/TCN_PLATFORM_REFERENCE.md
+++ b/docs/TCN_PLATFORM_REFERENCE.md
@@ -107,7 +107,32 @@ The password login service powers the mobile authentication flow, rate-limits br
   * `log_params` *(array, optional)* – Additional context stored with the log entry.
 * **Success response:** `{ ok: true }` after calling `Support\Logger::log()`.
 
-### 2.2 Profile & Media (`/wp-json/gn/v1/profile/avatar`)
+### 2.2 JWT Compatibility (`/wp-json/jwt-auth/v1/*`)
+
+The upstream **JWT Authentication for WP REST API** plugin exposes REST endpoints that many mobile apps and integrations rely on. TCN Platform now mirrors those routes so you can uninstall the standalone plugin while preserving the same contract.
+
+| Route | Method | Auth | Description |
+| --- | --- | --- | --- |
+| `/jwt-auth/v1/token` | POST | Public | Exchange a username/password for a signed JWT. |
+| `/jwt-auth/v1/token/refresh` | POST | Bearer token | Refresh an existing JWT and receive a new token. |
+| `/jwt-auth/v1/token/validate` | POST | Bearer token | Validate a JWT and confirm it is still active. |
+
+#### `POST /wp-json/jwt-auth/v1/token`
+* **Body**: `username`, `password` (required).
+* **Response**: `{ token, user_email, user_nicename, user_display_name, expires_in }`.
+* **Notes**: Mirrors the behaviour of the legacy plugin including filter hooks such as `jwt_auth_token_before_dispatch`.
+
+#### `POST /wp-json/jwt-auth/v1/token/refresh`
+* **Headers**: `Authorization: Bearer <token>` (or `token` request parameter).
+* **Response**: Same payload as the login endpoint with a newly-issued JWT.
+* **Notes**: Accepts expired tokens for refresh as long as the signature remains valid and the user still exists.
+
+#### `POST /wp-json/jwt-auth/v1/token/validate`
+* **Headers**: `Authorization: Bearer <token>` (or `token` request parameter).
+* **Response**: `{ code: 'jwt_auth_valid_token', message, data: { status: 200 } }` when valid.
+* **Notes**: Returns `jwt_auth_expired_token` or `jwt_auth_invalid_token` errors if the JWT is no longer valid.
+
+### 2.3 Profile & Media (`/wp-json/gn/v1/profile/avatar`)
 
 The profile endpoints let authenticated members update their avatar through the REST API. Authentication accepts either the WordPress cookie session or the bearer token issued by `/login`.
 
@@ -123,7 +148,7 @@ The profile endpoints let authenticated members update their avatar through the 
   * Upload validation issues → `400 tcn_avatar_missing`, `400/413/415 tcn_avatar_upload_error`, or `415 tcn_avatar_invalid_type`.
   * Attempting to upload for another user → `403 tcn_rest_forbidden`.
 
-### 2.3 Membership & MLM (`/wp-json/tcn-mlm/v1/*`, `/wp-json/gn/v1/memberships/*`)
+### 2.4 Membership & MLM (`/wp-json/tcn-mlm/v1/*`, `/wp-json/gn/v1/memberships/*`)
 
 Membership routes expose the member profile, genealogy tree, commission ledger, and upgrade flows. They all reuse the Password Login bearer token via `MembershipModule::rest_require_login()` unless marked public.
 
@@ -192,7 +217,7 @@ Returns `{ summary: {...}, ledger: [...] }` where `summary` mirrors the totals d
 * **Validation:** Confirms the plan exists, Stripe is configured when needed, the payment intent status is in `succeeded|processing|requires_capture`, the amount and currency match, and the metadata `plan` matches the request. Any mismatch returns a `409` error. Missing auth returns `401`.
 * **Success response:** `{ success: true, level: plan }` after assigning the sponsor, updating `_tcn_membership_level`, and recording commissions.【F:includes/Membership/MembershipModule.php†L480-L552】
 
-### 2.4 WooCommerce Bridges (`/wp-json/gn/v1/customers`, `/wp-json/gn/v1/orders`)
+### 2.5 WooCommerce Bridges (`/wp-json/gn/v1/customers`, `/wp-json/gn/v1/orders`)
 
 These endpoints bridge mobile clients to WooCommerce without exposing the entire WooCommerce REST API. Authentication succeeds when the requester can `manage_woocommerce` or presents a valid consumer key/secret pair (via Basic auth header or `consumer_key`/`consumer_secret` parameters). Keys must have `write` or `read_write` permissions; the user associated with the key is temporarily set as the current user for capability checks.【F:includes/Rest/WooCommerceEndpoints.php†L19-L131】【F:includes/Rest/WooCommerceEndpoints.php†L136-L214】
 

--- a/includes/Auth/JwtAuthEndpoints.php
+++ b/includes/Auth/JwtAuthEndpoints.php
@@ -1,0 +1,430 @@
+<?php
+namespace TCN\Platform\Auth;
+
+use WP_Error;
+use WP_REST_Request;
+use WP_User;
+
+/**
+ * Provide backwards-compatible JWT authentication endpoints.
+ *
+ * Mirrors the functionality of the upstream "JWT Authentication for WP REST API" plugin
+ * so third-party clients can rely on the documented endpoints while delegating to the
+ * TCN Platform authentication layer.
+ */
+class JwtAuthEndpoints {
+    /**
+     * REST namespace.
+     */
+    const REST_NAMESPACE = 'jwt-auth/v1';
+
+    /**
+     * Register REST routes.
+     */
+    public function register(): void {
+        add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+    }
+
+    /**
+     * Declare jwt-auth routes for issuing, refreshing, and validating tokens.
+     */
+    public function register_routes(): void {
+        register_rest_route(
+            self::REST_NAMESPACE,
+            '/token',
+            array(
+                'methods'             => 'POST',
+                'callback'            => array( $this, 'handle_token_request' ),
+                'permission_callback' => '__return_true',
+            )
+        );
+
+        register_rest_route(
+            self::REST_NAMESPACE,
+            '/token/refresh',
+            array(
+                'methods'             => 'POST',
+                'callback'            => array( $this, 'handle_refresh_request' ),
+                'permission_callback' => '__return_true',
+            )
+        );
+
+        register_rest_route(
+            self::REST_NAMESPACE,
+            '/token/validate',
+            array(
+                'methods'             => 'POST',
+                'callback'            => array( $this, 'handle_validate_request' ),
+                'permission_callback' => '__return_true',
+            )
+        );
+    }
+
+    /**
+     * Handle POST /jwt-auth/v1/token
+     */
+    public function handle_token_request( WP_REST_Request $request ) {
+        do_action( 'jwt_auth_before_auth', $request );
+
+        $username = (string) $request->get_param( 'username' );
+        $password = (string) $request->get_param( 'password' );
+
+        if ( '' === $username || '' === $password ) {
+            return new WP_Error(
+                'jwt_auth_missing_credentials',
+                __( 'Username and password are required.', 'tcnapp-connector' ),
+                array( 'status' => 400 )
+            );
+        }
+
+        $user = wp_authenticate( $username, $password );
+        if ( is_wp_error( $user ) ) {
+            do_action( 'jwt_auth_failed_auth', $user, $request );
+
+            return new WP_Error(
+                'jwt_auth_invalid_credentials',
+                __( 'Invalid username or password.', 'tcnapp-connector' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        do_action( 'jwt_auth_after_auth', $user, $request );
+
+        return $this->prepare_token_response( $user );
+    }
+
+    /**
+     * Handle POST /jwt-auth/v1/token/refresh
+     */
+    public function handle_refresh_request( WP_REST_Request $request ) {
+        $token = $this->extract_token_from_request( $request );
+        if ( is_wp_error( $token ) ) {
+            return $token;
+        }
+
+        $payload = $this->decode_token( $token, true );
+        if ( is_wp_error( $payload ) ) {
+            return $payload;
+        }
+
+        $user = $this->get_user_from_payload( $payload );
+        if ( ! $user ) {
+            return new WP_Error(
+                'jwt_auth_invalid_user',
+                __( 'The token user no longer exists.', 'tcnapp-connector' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        return $this->prepare_token_response( $user );
+    }
+
+    /**
+     * Handle POST /jwt-auth/v1/token/validate
+     */
+    public function handle_validate_request( WP_REST_Request $request ) {
+        $token = $this->extract_token_from_request( $request );
+        if ( is_wp_error( $token ) ) {
+            return $token;
+        }
+
+        $payload = $this->decode_token( $token );
+        if ( is_wp_error( $payload ) ) {
+            return $payload;
+        }
+
+        $response = array(
+            'code'    => 'jwt_auth_valid_token',
+            'message' => __( 'Token is valid.', 'tcnapp-connector' ),
+            'data'    => array( 'status' => 200 ),
+        );
+
+        return apply_filters( 'jwt_auth_validate_token_response', $response, $payload, $request );
+    }
+
+    /**
+     * Build a standard JWT response array.
+     */
+    protected function prepare_token_response( WP_User $user ) {
+        $token = $this->generate_token( $user );
+        if ( is_wp_error( $token ) ) {
+            return $token;
+        }
+
+        $payload = $token['payload'];
+        $jwt     = $token['token'];
+
+        $response = array(
+            'token'             => $jwt,
+            'user_email'        => $user->user_email,
+            'user_nicename'     => $user->user_nicename,
+            'user_display_name' => $user->display_name,
+        );
+
+        if ( isset( $payload['exp'] ) ) {
+            $response['expires_in'] = max( 0, (int) $payload['exp'] - time() );
+        }
+
+        $response = apply_filters( 'jwt_auth_token_before_dispatch', $response, $user, $payload );
+
+        return apply_filters( 'jwt_auth_token_response', $response, $user, $payload );
+    }
+
+    /**
+     * Generate a signed JWT for a user.
+     */
+    protected function generate_token( WP_User $user ) {
+        $issued_at  = time();
+        $not_before = apply_filters( 'jwt_auth_not_before', $issued_at, $user );
+        $expire     = apply_filters( 'jwt_auth_expire', $issued_at + DAY_IN_SECONDS, $issued_at, $user );
+
+        $payload = array(
+            'iss'  => apply_filters( 'jwt_auth_iss', get_bloginfo( 'url' ), $user ),
+            'iat'  => $issued_at,
+            'nbf'  => $not_before,
+            'exp'  => $expire,
+            'data' => array(
+                'user' => array(
+                    'id' => $user->ID,
+                ),
+            ),
+        );
+
+        $payload = apply_filters( 'jwt_auth_token_payload', $payload, $user );
+
+        $token = $this->encode_jwt( $payload );
+        if ( is_wp_error( $token ) ) {
+            return $token;
+        }
+
+        return array(
+            'token'   => $token,
+            'payload' => $payload,
+        );
+    }
+
+    /**
+     * Encode payload as JWT.
+     */
+    protected function encode_jwt( array $payload ) {
+        $secret = $this->get_secret_key();
+        if ( empty( $secret ) ) {
+            return new WP_Error(
+                'jwt_auth_bad_config',
+                __( 'JWT secret key is not configured.', 'tcnapp-connector' ),
+                array( 'status' => 500 )
+            );
+        }
+
+        $algo = strtoupper( (string) apply_filters( 'jwt_auth_alg', 'HS256', $payload ) );
+        if ( 'HS256' !== $algo ) {
+            return new WP_Error(
+                'jwt_auth_unsupported_alg',
+                __( 'Only the HS256 signing algorithm is supported.', 'tcnapp-connector' ),
+                array( 'status' => 500 )
+            );
+        }
+
+        $header = array(
+            'alg' => $algo,
+            'typ' => 'JWT',
+        );
+
+        $segments   = array();
+        $segments[] = $this->base64url_encode( wp_json_encode( $header ) );
+        $segments[] = $this->base64url_encode( wp_json_encode( $payload ) );
+
+        $signature = hash_hmac( 'sha256', implode( '.', $segments ), $secret, true );
+        $segments[] = $this->base64url_encode( $signature );
+
+        return implode( '.', $segments );
+    }
+
+    /**
+     * Decode and validate a JWT.
+     */
+    protected function decode_token( string $token, bool $allow_expired = false ) {
+        $parts = explode( '.', $token );
+        if ( 3 !== count( $parts ) ) {
+            return new WP_Error(
+                'jwt_auth_invalid_token',
+                __( 'The token structure is invalid.', 'tcnapp-connector' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        list( $header64, $payload64, $signature64 ) = $parts;
+
+        $header_json = $this->base64url_decode( $header64 );
+        if ( false === $header_json ) {
+            return new WP_Error(
+                'jwt_auth_invalid_token',
+                __( 'The token header could not be decoded.', 'tcnapp-connector' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        $header = json_decode( $header_json, true );
+        if ( ! is_array( $header ) ) {
+            return new WP_Error(
+                'jwt_auth_invalid_token',
+                __( 'The token header is invalid.', 'tcnapp-connector' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        $algo = strtoupper( (string) ( $header['alg'] ?? 'HS256' ) );
+        if ( 'HS256' !== $algo ) {
+            return new WP_Error(
+                'jwt_auth_unsupported_alg',
+                __( 'Only the HS256 signing algorithm is supported.', 'tcnapp-connector' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        $secret = $this->get_secret_key();
+        if ( empty( $secret ) ) {
+            return new WP_Error(
+                'jwt_auth_bad_config',
+                __( 'JWT secret key is not configured.', 'tcnapp-connector' ),
+                array( 'status' => 500 )
+            );
+        }
+
+        $signature = $this->base64url_decode( $signature64 );
+        if ( false === $signature ) {
+            return new WP_Error(
+                'jwt_auth_invalid_token',
+                __( 'The token signature could not be decoded.', 'tcnapp-connector' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        $expected = hash_hmac( 'sha256', $header64 . '.' . $payload64, $secret, true );
+        if ( ! hash_equals( $expected, $signature ) ) {
+            return new WP_Error(
+                'jwt_auth_invalid_token',
+                __( 'The token signature is invalid.', 'tcnapp-connector' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        $payload_json = $this->base64url_decode( $payload64 );
+        if ( false === $payload_json ) {
+            return new WP_Error(
+                'jwt_auth_invalid_token',
+                __( 'The token payload could not be decoded.', 'tcnapp-connector' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        $payload = json_decode( $payload_json, true );
+        if ( ! is_array( $payload ) ) {
+            return new WP_Error(
+                'jwt_auth_invalid_token',
+                __( 'The token payload is invalid.', 'tcnapp-connector' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        $now    = time();
+        $leeway = apply_filters( 'jwt_auth_leeway', 0, $payload );
+
+        if ( isset( $payload['nbf'] ) && ( $payload['nbf'] - $leeway ) > $now ) {
+            return new WP_Error(
+                'jwt_auth_invalid_token',
+                __( 'The token is not yet valid.', 'tcnapp-connector' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        if ( ! $allow_expired && isset( $payload['exp'] ) && ( $now - $leeway ) >= $payload['exp'] ) {
+            return new WP_Error(
+                'jwt_auth_expired_token',
+                __( 'The token has expired.', 'tcnapp-connector' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        return apply_filters( 'jwt_auth_decoded_payload', $payload, $token );
+    }
+
+    /**
+     * Resolve WP_User from JWT payload.
+     */
+    protected function get_user_from_payload( array $payload ) {
+        $user_id = $payload['data']['user']['id'] ?? 0;
+        if ( ! $user_id ) {
+            return null;
+        }
+
+        $user = get_user_by( 'id', (int) $user_id );
+        if ( ! $user instanceof WP_User ) {
+            return null;
+        }
+
+        return $user;
+    }
+
+    /**
+     * Extract bearer token from Authorization header or request parameter.
+     */
+    protected function extract_token_from_request( WP_REST_Request $request ) {
+        $auth = $request->get_header( 'authorization' );
+        if ( $auth && 0 === stripos( $auth, 'bearer ' ) ) {
+            $token = trim( substr( $auth, 7 ) );
+            if ( '' !== $token ) {
+                return $token;
+            }
+        }
+
+        $token = (string) $request->get_param( 'token' );
+        if ( '' !== $token ) {
+            return $token;
+        }
+
+        return new WP_Error(
+            'jwt_auth_missing_token',
+            __( 'Authorization header or token parameter is required.', 'tcnapp-connector' ),
+            array( 'status' => 401 )
+        );
+    }
+
+    /**
+     * Retrieve the signing secret key.
+     */
+    protected function get_secret_key(): string {
+        $secret = defined( 'JWT_AUTH_SECRET_KEY' ) ? constant( 'JWT_AUTH_SECRET_KEY' ) : '';
+        $secret = apply_filters( 'jwt_auth_secret_key', $secret );
+
+        if ( empty( $secret ) ) {
+            $secret = wp_salt( 'auth' );
+        }
+
+        return (string) $secret;
+    }
+
+    /**
+     * Base64 URL-safe encode helper.
+     */
+    protected function base64url_encode( $data ) {
+        return rtrim( strtr( base64_encode( (string) $data ), '+/', '-_' ), '=' );
+    }
+
+    /**
+     * Base64 URL-safe decode helper.
+     */
+    protected function base64url_decode( string $data ) {
+        $remainder = strlen( $data ) % 4;
+        if ( $remainder ) {
+            $data .= str_repeat( '=', 4 - $remainder );
+        }
+
+        $decoded = base64_decode( strtr( $data, '-_', '+/' ), true );
+        if ( false === $decoded ) {
+            return false;
+        }
+
+        return $decoded;
+    }
+}

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -6,6 +6,7 @@ use TCN\Platform\Admin\ApiTesterPage;
 use TCN\Platform\Admin\ChecklistPage;
 use TCN\Platform\Admin\LogPage;
 use TCN\Platform\Admin\SettingsPage;
+use TCN\Platform\Auth\JwtAuthEndpoints;
 use TCN\Platform\Auth\PasswordLoginService;
 use TCN\Platform\Auth\TokenAuthenticator;
 use TCN\Platform\Membership\MembershipModule;
@@ -60,6 +61,7 @@ class Plugin {
 
         if ( $this->modules->is_enabled( Modules::MODULE_AUTH_LOGIN ) ) {
             $this->services[] = new PasswordLoginService( $token_authenticator );
+            $this->services[] = new JwtAuthEndpoints();
         } else {
             PasswordLoginService::register_compatibility_alias();
         }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.58
+Stable tag: 0.3.59
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.59 =
+* Add `/jwt-auth/v1` compatibility endpoints that mirror the "JWT Authentication for WP REST API" plugin so mobile apps continue to authenticate without additional dependencies.
+
 = 0.3.58 =
 * Reduce memory usage when reading membership product data by loading WooCommerce product IDs and metadata on demand instead of instantiating every product object at once.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.58
+ * Version:           0.3.59
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.58' );
+define( 'TCN_PLATFORM_VERSION', '0.3.59' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- add a JwtAuthEndpoints service that mirrors the jwt-auth/v1 token, refresh, and validate routes and signs HS256 JWTs with the existing secret salt
- register the JWT compatibility routes when the Password Login module is enabled and document the endpoints in the API reference
- bump the plugin to version 0.3.59 and update public release notes and changelog entries

## Testing
- php -l includes/Auth/JwtAuthEndpoints.php

------
https://chatgpt.com/codex/tasks/task_e_68e429badef48327902d37c65210606b