### PR TITLE
Expand API tester presets to include JWT compatibility routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.60
+- Expand the API tester presets so every REST endpoint—including the `/jwt-auth/v1` compatibility routes—can be populated and exercised directly from the WordPress dashboard.
+
 ### 0.3.59
 - Mirror the `jwt-auth/v1` REST endpoints from the standalone JWT Authentication plugin so existing clients can obtain, refresh, and validate JWTs without additional dependencies.
 

--- a/docs/TCN_PLATFORM_REFERENCE.md
+++ b/docs/TCN_PLATFORM_REFERENCE.md
@@ -514,4 +514,4 @@ The tables below enumerate every method, its visibility, parameters, return valu
 
 ---
 
-With this reference and the expanded API tester presets, every endpoint (including WooCommerce bridges) can be exercised in seconds from within WordPress. Combine the method tables with your IDE or code reviews to trace hooks, REST callbacks, and WooCommerce touch points without hunting through the source.
+With this reference and the expanded API tester presets, every endpoint (including WooCommerce bridges and the JWT compatibility routes) can be exercised in seconds from within WordPress. Combine the method tables with your IDE or code reviews to trace hooks, REST callbacks, and WooCommerce touch points without hunting through the source.

--- a/includes/Admin/ApiTesterPage.php
+++ b/includes/Admin/ApiTesterPage.php
@@ -385,6 +385,9 @@ class ApiTesterPage {
         $commissions_url  = home_url( '/wp-json/tcn-mlm/v1/commissions' );
         $customer_url     = home_url( '/wp-json/gn/v1/customers' );
         $orders_url       = home_url( '/wp-json/gn/v1/orders' );
+        $jwt_token_url    = home_url( '/wp-json/jwt-auth/v1/token' );
+        $jwt_refresh_url  = home_url( '/wp-json/jwt-auth/v1/token/refresh' );
+        $jwt_validate_url = home_url( '/wp-json/jwt-auth/v1/token/validate' );
 
         return array(
             array(
@@ -409,6 +412,88 @@ class ApiTesterPage {
                         'user'       => array(
                             'id'    => 123,
                             'email' => 'demo@example.com',
+                        ),
+                    ),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                ) ?: '',
+            ),
+            array(
+                'method'      => 'POST',
+                'url'         => $jwt_token_url,
+                'description' => __( 'Issue a JWT compatible with the legacy jwt-auth plugin.', 'tcnapp-connector' ),
+                'note'        => __( 'Public endpoint that mirrors “JWT Authentication for WP REST API” responses.', 'tcnapp-connector' ),
+                'headers'     => wp_json_encode( array( 'Content-Type' => 'application/json' ), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ?: '',
+                'body'        => wp_json_encode(
+                    array(
+                        'username' => 'demo@example.com',
+                        'password' => 'secret-password',
+                    ),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                ) ?: '',
+                'response'    => wp_json_encode(
+                    array(
+                        'token'             => 'example.jwt.token',
+                        'user_email'        => 'demo@example.com',
+                        'user_nicename'     => 'demo',
+                        'user_display_name' => 'Demo User',
+                        'expires_in'        => 86400,
+                    ),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                ) ?: '',
+            ),
+            array(
+                'method'      => 'POST',
+                'url'         => $jwt_refresh_url,
+                'description' => __( 'Refresh a JWT using the compatibility endpoints.', 'tcnapp-connector' ),
+                'note'        => __( 'Send the existing token in the Authorization header or token parameter.', 'tcnapp-connector' ),
+                'headers'     => wp_json_encode(
+                    array(
+                        'Content-Type'  => 'application/json',
+                        'Authorization' => 'Bearer paste-jwt-token-here',
+                    ),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                ) ?: '',
+                'body'        => wp_json_encode(
+                    array(
+                        'token' => 'paste-jwt-token-here',
+                    ),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                ) ?: '',
+                'response'    => wp_json_encode(
+                    array(
+                        'token'             => 'refreshed.jwt.token',
+                        'user_email'        => 'demo@example.com',
+                        'user_nicename'     => 'demo',
+                        'user_display_name' => 'Demo User',
+                        'expires_in'        => 86400,
+                    ),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                ) ?: '',
+            ),
+            array(
+                'method'      => 'POST',
+                'url'         => $jwt_validate_url,
+                'description' => __( 'Validate a JWT and confirm it is still active.', 'tcnapp-connector' ),
+                'note'        => __( 'Requires the JWT in the Authorization header or token body parameter.', 'tcnapp-connector' ),
+                'headers'     => wp_json_encode(
+                    array(
+                        'Content-Type'  => 'application/json',
+                        'Authorization' => 'Bearer paste-jwt-token-here',
+                    ),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                ) ?: '',
+                'body'        => wp_json_encode(
+                    array(
+                        'token' => 'paste-jwt-token-here',
+                    ),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                ) ?: '',
+                'response'    => wp_json_encode(
+                    array(
+                        'code'    => 'jwt_auth_valid_token',
+                        'message' => __( 'Token is valid.', 'tcnapp-connector' ),
+                        'data'    => array(
+                            'status' => 200,
                         ),
                     ),
                     JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.59
+Stable tag: 0.3.60
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.60 =
+* Expand the API tester presets to cover every available REST endpoint, including the `/jwt-auth/v1` compatibility routes, so administrators can validate JWT flows alongside the existing GN and MLM examples.
+
 = 0.3.59 =
 * Add `/jwt-auth/v1` compatibility endpoints that mirror the "JWT Authentication for WP REST API" plugin so mobile apps continue to authenticate without additional dependencies.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.59
+ * Version:           0.3.60
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.59' );
+define( 'TCN_PLATFORM_VERSION', '0.3.60' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- extend the API tester presets with JWT token, refresh, and validate examples so every REST route is surfaced in the admin UI
- bump the plugin version to 0.3.60 and update public documentation to note the expanded coverage

## Testing
- php -l includes/Admin/ApiTesterPage.php

------
https://chatgpt.com/codex/tasks/task_e_68e4350ea9dc83278c4c299f62951698