### PR TITLE
Restore JWT login tokens and bump version to 0.3.61

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.61
+- Restore JWT responses for `/wp-json/gn/v1/login` so mobile and third-party clients receive signed bearer tokens again.
+- Refactor the shared JWT helpers into a reusable service consumed by both the password login API and the `/jwt-auth/v1` compatibility routes.
+
 ### 0.3.60
 - Expand the API tester presets so every REST endpoint—including the `/jwt-auth/v1` compatibility routes—can be populated and exercised directly from the WordPress dashboard.
 

--- a/docs/TCN_PLATFORM_REFERENCE.md
+++ b/docs/TCN_PLATFORM_REFERENCE.md
@@ -38,7 +38,7 @@ The password login service powers the mobile authentication flow, rate-limits br
 #### Shared request & response behaviour
 
 * **Rate limiting:** The login endpoint tracks attempts per `{action}:{identifier}:{IP}` using the configured `rate_limit` and `rate_limit_window` values. Excessive failures return `429 gn_rate_limited` until the TTL expires.【F:includes/Auth/PasswordLoginService.php†L158-L205】【F:includes/Auth/PasswordLoginService.php†L508-L548】
-* **Token lifetime:** `token` (for one-click WordPress login) and `api_token` (for REST bearer auth) both default to seven days and are stored as WordPress transients with matching expiration timestamps.【F:includes/Auth/PasswordLoginService.php†L186-L209】【F:includes/Auth/PasswordLoginService.php†L560-L599】
+* **Token lifetime:** `token` (for one-click WordPress login) and the JWT-backed `api_token` (for REST bearer auth) both default to seven days. The API token is hashed into a transient for validation while the signed JWT payload retains the same expiry.【F:includes/Auth/PasswordLoginService.php†L186-L209】【F:includes/Auth/PasswordLoginService.php†L566-L610】【F:includes/Auth/JwtTokenService.php†L14-L57】
 * **User payload:** Responses include `id`, `username`, `email`, `display_name`, `first_name`, `last_name`, `membership_level`, `sponsor_id`, and optional `woocommerce` credentials (consumer key/secret + base64 `authorization`).【F:includes/Auth/PasswordLoginService.php†L456-L485】
 * **Error format:** Failures are returned as `WP_Error` with descriptive messages and HTTP codes (400 for validation, 401/403 for auth, 404 for unknown users, 409 for conflicts, 429 for rate limiting).【F:includes/Auth/PasswordLoginService.php†L146-L237】【F:includes/Auth/PasswordLoginService.php†L260-L392】
 

--- a/includes/Auth/JwtAuthEndpoints.php
+++ b/includes/Auth/JwtAuthEndpoints.php
@@ -102,7 +102,7 @@ class JwtAuthEndpoints {
             return $token;
         }
 
-        $payload = $this->decode_token( $token, true );
+        $payload = JwtTokenService::decode_token( $token, true );
         if ( is_wp_error( $payload ) ) {
             return $payload;
         }
@@ -128,7 +128,7 @@ class JwtAuthEndpoints {
             return $token;
         }
 
-        $payload = $this->decode_token( $token );
+        $payload = JwtTokenService::decode_token( $token );
         if ( is_wp_error( $payload ) ) {
             return $payload;
         }
@@ -146,7 +146,7 @@ class JwtAuthEndpoints {
      * Build a standard JWT response array.
      */
     protected function prepare_token_response( WP_User $user ) {
-        $token = $this->generate_token( $user );
+        $token = JwtTokenService::generate_token( $user );
         if ( is_wp_error( $token ) ) {
             return $token;
         }
@@ -168,185 +168,6 @@ class JwtAuthEndpoints {
         $response = apply_filters( 'jwt_auth_token_before_dispatch', $response, $user, $payload );
 
         return apply_filters( 'jwt_auth_token_response', $response, $user, $payload );
-    }
-
-    /**
-     * Generate a signed JWT for a user.
-     */
-    protected function generate_token( WP_User $user ) {
-        $issued_at  = time();
-        $not_before = apply_filters( 'jwt_auth_not_before', $issued_at, $user );
-        $expire     = apply_filters( 'jwt_auth_expire', $issued_at + DAY_IN_SECONDS, $issued_at, $user );
-
-        $payload = array(
-            'iss'  => apply_filters( 'jwt_auth_iss', get_bloginfo( 'url' ), $user ),
-            'iat'  => $issued_at,
-            'nbf'  => $not_before,
-            'exp'  => $expire,
-            'data' => array(
-                'user' => array(
-                    'id' => $user->ID,
-                ),
-            ),
-        );
-
-        $payload = apply_filters( 'jwt_auth_token_payload', $payload, $user );
-
-        $token = $this->encode_jwt( $payload );
-        if ( is_wp_error( $token ) ) {
-            return $token;
-        }
-
-        return array(
-            'token'   => $token,
-            'payload' => $payload,
-        );
-    }
-
-    /**
-     * Encode payload as JWT.
-     */
-    protected function encode_jwt( array $payload ) {
-        $secret = $this->get_secret_key();
-        if ( empty( $secret ) ) {
-            return new WP_Error(
-                'jwt_auth_bad_config',
-                __( 'JWT secret key is not configured.', 'tcnapp-connector' ),
-                array( 'status' => 500 )
-            );
-        }
-
-        $algo = strtoupper( (string) apply_filters( 'jwt_auth_alg', 'HS256', $payload ) );
-        if ( 'HS256' !== $algo ) {
-            return new WP_Error(
-                'jwt_auth_unsupported_alg',
-                __( 'Only the HS256 signing algorithm is supported.', 'tcnapp-connector' ),
-                array( 'status' => 500 )
-            );
-        }
-
-        $header = array(
-            'alg' => $algo,
-            'typ' => 'JWT',
-        );
-
-        $segments   = array();
-        $segments[] = $this->base64url_encode( wp_json_encode( $header ) );
-        $segments[] = $this->base64url_encode( wp_json_encode( $payload ) );
-
-        $signature = hash_hmac( 'sha256', implode( '.', $segments ), $secret, true );
-        $segments[] = $this->base64url_encode( $signature );
-
-        return implode( '.', $segments );
-    }
-
-    /**
-     * Decode and validate a JWT.
-     */
-    protected function decode_token( string $token, bool $allow_expired = false ) {
-        $parts = explode( '.', $token );
-        if ( 3 !== count( $parts ) ) {
-            return new WP_Error(
-                'jwt_auth_invalid_token',
-                __( 'The token structure is invalid.', 'tcnapp-connector' ),
-                array( 'status' => 403 )
-            );
-        }
-
-        list( $header64, $payload64, $signature64 ) = $parts;
-
-        $header_json = $this->base64url_decode( $header64 );
-        if ( false === $header_json ) {
-            return new WP_Error(
-                'jwt_auth_invalid_token',
-                __( 'The token header could not be decoded.', 'tcnapp-connector' ),
-                array( 'status' => 403 )
-            );
-        }
-
-        $header = json_decode( $header_json, true );
-        if ( ! is_array( $header ) ) {
-            return new WP_Error(
-                'jwt_auth_invalid_token',
-                __( 'The token header is invalid.', 'tcnapp-connector' ),
-                array( 'status' => 403 )
-            );
-        }
-
-        $algo = strtoupper( (string) ( $header['alg'] ?? 'HS256' ) );
-        if ( 'HS256' !== $algo ) {
-            return new WP_Error(
-                'jwt_auth_unsupported_alg',
-                __( 'Only the HS256 signing algorithm is supported.', 'tcnapp-connector' ),
-                array( 'status' => 403 )
-            );
-        }
-
-        $secret = $this->get_secret_key();
-        if ( empty( $secret ) ) {
-            return new WP_Error(
-                'jwt_auth_bad_config',
-                __( 'JWT secret key is not configured.', 'tcnapp-connector' ),
-                array( 'status' => 500 )
-            );
-        }
-
-        $signature = $this->base64url_decode( $signature64 );
-        if ( false === $signature ) {
-            return new WP_Error(
-                'jwt_auth_invalid_token',
-                __( 'The token signature could not be decoded.', 'tcnapp-connector' ),
-                array( 'status' => 403 )
-            );
-        }
-
-        $expected = hash_hmac( 'sha256', $header64 . '.' . $payload64, $secret, true );
-        if ( ! hash_equals( $expected, $signature ) ) {
-            return new WP_Error(
-                'jwt_auth_invalid_token',
-                __( 'The token signature is invalid.', 'tcnapp-connector' ),
-                array( 'status' => 403 )
-            );
-        }
-
-        $payload_json = $this->base64url_decode( $payload64 );
-        if ( false === $payload_json ) {
-            return new WP_Error(
-                'jwt_auth_invalid_token',
-                __( 'The token payload could not be decoded.', 'tcnapp-connector' ),
-                array( 'status' => 403 )
-            );
-        }
-
-        $payload = json_decode( $payload_json, true );
-        if ( ! is_array( $payload ) ) {
-            return new WP_Error(
-                'jwt_auth_invalid_token',
-                __( 'The token payload is invalid.', 'tcnapp-connector' ),
-                array( 'status' => 403 )
-            );
-        }
-
-        $now    = time();
-        $leeway = apply_filters( 'jwt_auth_leeway', 0, $payload );
-
-        if ( isset( $payload['nbf'] ) && ( $payload['nbf'] - $leeway ) > $now ) {
-            return new WP_Error(
-                'jwt_auth_invalid_token',
-                __( 'The token is not yet valid.', 'tcnapp-connector' ),
-                array( 'status' => 403 )
-            );
-        }
-
-        if ( ! $allow_expired && isset( $payload['exp'] ) && ( $now - $leeway ) >= $payload['exp'] ) {
-            return new WP_Error(
-                'jwt_auth_expired_token',
-                __( 'The token has expired.', 'tcnapp-connector' ),
-                array( 'status' => 403 )
-            );
-        }
-
-        return apply_filters( 'jwt_auth_decoded_payload', $payload, $token );
     }
 
     /**
@@ -388,43 +209,5 @@ class JwtAuthEndpoints {
             __( 'Authorization header or token parameter is required.', 'tcnapp-connector' ),
             array( 'status' => 401 )
         );
-    }
-
-    /**
-     * Retrieve the signing secret key.
-     */
-    protected function get_secret_key(): string {
-        $secret = defined( 'JWT_AUTH_SECRET_KEY' ) ? constant( 'JWT_AUTH_SECRET_KEY' ) : '';
-        $secret = apply_filters( 'jwt_auth_secret_key', $secret );
-
-        if ( empty( $secret ) ) {
-            $secret = wp_salt( 'auth' );
-        }
-
-        return (string) $secret;
-    }
-
-    /**
-     * Base64 URL-safe encode helper.
-     */
-    protected function base64url_encode( $data ) {
-        return rtrim( strtr( base64_encode( (string) $data ), '+/', '-_' ), '=' );
-    }
-
-    /**
-     * Base64 URL-safe decode helper.
-     */
-    protected function base64url_decode( string $data ) {
-        $remainder = strlen( $data ) % 4;
-        if ( $remainder ) {
-            $data .= str_repeat( '=', 4 - $remainder );
-        }
-
-        $decoded = base64_decode( strtr( $data, '-_', '+/' ), true );
-        if ( false === $decoded ) {
-            return false;
-        }
-
-        return $decoded;
     }
 }

--- a/includes/Auth/JwtTokenService.php
+++ b/includes/Auth/JwtTokenService.php
@@ -1,0 +1,259 @@
+<?php
+namespace TCN\Platform\Auth;
+
+use WP_Error;
+use WP_User;
+
+/**
+ * Shared helpers for issuing and validating JWT tokens.
+ */
+class JwtTokenService {
+    /**
+     * Generate a signed JWT for a user.
+     *
+     * @param WP_User                $user      User to include in the token payload.
+     * @param array<string, mixed>   $overrides Optional overrides such as `issued_at`, `not_before`, `expire`, or `payload`.
+     *
+     * @return array{token: string, payload: array<string, mixed>}|WP_Error
+     */
+    public static function generate_token( WP_User $user, array $overrides = array() ) {
+        $issued_at = isset( $overrides['issued_at'] ) ? (int) $overrides['issued_at'] : time();
+
+        if ( array_key_exists( 'not_before', $overrides ) ) {
+            $not_before = (int) $overrides['not_before'];
+        } else {
+            $not_before = apply_filters( 'jwt_auth_not_before', $issued_at, $user );
+        }
+
+        $default_expire = $issued_at + DAY_IN_SECONDS;
+        $expire         = array_key_exists( 'expire', $overrides ) ? (int) $overrides['expire'] : $default_expire;
+        $expire         = apply_filters( 'jwt_auth_expire', $expire, $issued_at, $user );
+
+        $payload = array(
+            'iss'  => apply_filters( 'jwt_auth_iss', get_bloginfo( 'url' ), $user ),
+            'iat'  => $issued_at,
+            'nbf'  => $not_before,
+            'exp'  => $expire,
+            'data' => array(
+                'user' => array(
+                    'id' => $user->ID,
+                ),
+            ),
+        );
+
+        if ( isset( $overrides['payload'] ) && is_array( $overrides['payload'] ) ) {
+            $payload = array_replace_recursive( $payload, $overrides['payload'] );
+        }
+
+        $payload = apply_filters( 'jwt_auth_token_payload', $payload, $user );
+
+        $token = self::encode_jwt( $payload );
+        if ( is_wp_error( $token ) ) {
+            return $token;
+        }
+
+        return array(
+            'token'   => $token,
+            'payload' => $payload,
+        );
+    }
+
+    /**
+     * Decode and validate a JWT token.
+     *
+     * @param string $token         Encoded JWT string.
+     * @param bool   $allow_expired Allow expired tokens.
+     *
+     * @return array<string, mixed>|WP_Error
+     */
+    public static function decode_token( string $token, bool $allow_expired = false ) {
+        $parts = explode( '.', $token );
+        if ( 3 !== count( $parts ) ) {
+            return new WP_Error(
+                'jwt_auth_invalid_token',
+                __( 'The token structure is invalid.', 'tcnapp-connector' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        list( $header64, $payload64, $signature64 ) = $parts;
+
+        $header_json = self::base64url_decode( $header64 );
+        if ( false === $header_json ) {
+            return new WP_Error(
+                'jwt_auth_invalid_token',
+                __( 'The token header could not be decoded.', 'tcnapp-connector' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        $header = json_decode( $header_json, true );
+        if ( ! is_array( $header ) ) {
+            return new WP_Error(
+                'jwt_auth_invalid_token',
+                __( 'The token header is invalid.', 'tcnapp-connector' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        $algo = strtoupper( (string) ( $header['alg'] ?? 'HS256' ) );
+        if ( 'HS256' !== $algo ) {
+            return new WP_Error(
+                'jwt_auth_unsupported_alg',
+                __( 'Only the HS256 signing algorithm is supported.', 'tcnapp-connector' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        $secret = self::get_secret_key();
+        if ( empty( $secret ) ) {
+            return new WP_Error(
+                'jwt_auth_bad_config',
+                __( 'JWT secret key is not configured.', 'tcnapp-connector' ),
+                array( 'status' => 500 )
+            );
+        }
+
+        $signature = self::base64url_decode( $signature64 );
+        if ( false === $signature ) {
+            return new WP_Error(
+                'jwt_auth_invalid_token',
+                __( 'The token signature could not be decoded.', 'tcnapp-connector' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        $expected = hash_hmac( 'sha256', $header64 . '.' . $payload64, $secret, true );
+        if ( ! hash_equals( $expected, $signature ) ) {
+            return new WP_Error(
+                'jwt_auth_invalid_token',
+                __( 'The token signature is invalid.', 'tcnapp-connector' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        $payload_json = self::base64url_decode( $payload64 );
+        if ( false === $payload_json ) {
+            return new WP_Error(
+                'jwt_auth_invalid_token',
+                __( 'The token payload could not be decoded.', 'tcnapp-connector' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        $payload = json_decode( $payload_json, true );
+        if ( ! is_array( $payload ) ) {
+            return new WP_Error(
+                'jwt_auth_invalid_token',
+                __( 'The token payload is invalid.', 'tcnapp-connector' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        $now    = time();
+        $leeway = apply_filters( 'jwt_auth_leeway', 0, $payload );
+
+        if ( isset( $payload['nbf'] ) && ( $payload['nbf'] - $leeway ) > $now ) {
+            return new WP_Error(
+                'jwt_auth_invalid_token',
+                __( 'The token is not yet valid.', 'tcnapp-connector' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        if ( ! $allow_expired && isset( $payload['exp'] ) && ( $now - $leeway ) >= $payload['exp'] ) {
+            return new WP_Error(
+                'jwt_auth_expired_token',
+                __( 'The token has expired.', 'tcnapp-connector' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        return apply_filters( 'jwt_auth_decoded_payload', $payload, $token );
+    }
+
+    /**
+     * Encode payload as a JWT string.
+     *
+     * @param array<string, mixed> $payload Token payload.
+     *
+     * @return string|WP_Error
+     */
+    public static function encode_jwt( array $payload ) {
+        $secret = self::get_secret_key();
+        if ( empty( $secret ) ) {
+            return new WP_Error(
+                'jwt_auth_bad_config',
+                __( 'JWT secret key is not configured.', 'tcnapp-connector' ),
+                array( 'status' => 500 )
+            );
+        }
+
+        $algo = strtoupper( (string) apply_filters( 'jwt_auth_alg', 'HS256', $payload ) );
+        if ( 'HS256' !== $algo ) {
+            return new WP_Error(
+                'jwt_auth_unsupported_alg',
+                __( 'Only the HS256 signing algorithm is supported.', 'tcnapp-connector' ),
+                array( 'status' => 500 )
+            );
+        }
+
+        $header = array(
+            'alg' => $algo,
+            'typ' => 'JWT',
+        );
+
+        $segments   = array();
+        $segments[] = self::base64url_encode( wp_json_encode( $header ) );
+        $segments[] = self::base64url_encode( wp_json_encode( $payload ) );
+
+        $signature = hash_hmac( 'sha256', implode( '.', $segments ), $secret, true );
+        $segments[] = self::base64url_encode( $signature );
+
+        return implode( '.', $segments );
+    }
+
+    /**
+     * Retrieve the signing secret key.
+     */
+    public static function get_secret_key(): string {
+        $secret = defined( 'JWT_AUTH_SECRET_KEY' ) ? constant( 'JWT_AUTH_SECRET_KEY' ) : '';
+        $secret = apply_filters( 'jwt_auth_secret_key', $secret );
+
+        if ( empty( $secret ) ) {
+            $secret = wp_salt( 'auth' );
+        }
+
+        return (string) $secret;
+    }
+
+    /**
+     * Base64 URL-safe encode helper.
+     *
+     * @param string $data Raw data to encode.
+     */
+    protected static function base64url_encode( $data ) {
+        return rtrim( strtr( base64_encode( (string) $data ), '+/', '-_' ), '=' );
+    }
+
+    /**
+     * Base64 URL-safe decode helper.
+     *
+     * @param string $data Encoded data.
+     *
+     * @return string|false
+     */
+    protected static function base64url_decode( string $data ) {
+        $remainder = strlen( $data ) % 4;
+        if ( $remainder ) {
+            $data .= str_repeat( '=', 4 - $remainder );
+        }
+
+        $decoded = base64_decode( strtr( $data, '-_', '+/' ), true );
+        if ( false === $decoded ) {
+            return false;
+        }
+
+        return $decoded;
+    }
+}

--- a/includes/Auth/PasswordLoginService.php
+++ b/includes/Auth/PasswordLoginService.php
@@ -573,21 +573,48 @@ class PasswordLoginService {
     }
 
     protected function issue_api_token( int $user_id ): array {
-        $lifetime = DAY_IN_SECONDS * 7;
-        $token    = wp_generate_password( 64, false );
+        $lifetime = (int) apply_filters( 'gn_password_api_api_token_lifetime', DAY_IN_SECONDS * 7, $user_id );
+        $lifetime = max( HOUR_IN_SECONDS, $lifetime );
+
+        $user = get_user_by( 'id', $user_id );
+
+        $jwt_token  = null;
+        $expires_at = time() + $lifetime;
+
+        if ( $user instanceof WP_User ) {
+            $jwt_token = JwtTokenService::generate_token(
+                $user,
+                array(
+                    'expire' => $expires_at,
+                )
+            );
+        }
+
+        if ( $jwt_token instanceof WP_Error || ! is_array( $jwt_token ) ) {
+            $token_string = wp_generate_password( 64, false );
+        } else {
+            $token_string = $jwt_token['token'];
+            $payload      = $jwt_token['payload'];
+
+            if ( isset( $payload['exp'] ) && (int) $payload['exp'] > 0 ) {
+                $expires_at = (int) $payload['exp'];
+            }
+        }
+
+        $ttl = max( 1, $expires_at - time() );
 
         set_transient(
-            self::API_TOKEN_PREFIX . md5( $token ),
+            self::API_TOKEN_PREFIX . md5( $token_string ),
             array(
                 'user_id' => $user_id,
-                'exp'     => time() + $lifetime,
+                'exp'     => $expires_at,
             ),
-            $lifetime
+            $ttl
         );
 
         return array(
-            'token'      => $token,
-            'expires_in' => $lifetime,
+            'token'      => $token_string,
+            'expires_in' => max( 0, $expires_at - time() ),
         );
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.60
+Stable tag: 0.3.61
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,10 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.61 =
+* Restore JWT responses for `/wp-json/gn/v1/login` so mobile clients once again receive signed bearer tokens alongside password reset and profile flows.
+* Share the JWT encoder/decoder with the `/jwt-auth/v1` compatibility endpoints to keep refresh and validate behaviour aligned.
+
 = 0.3.60 =
 * Expand the API tester presets to cover every available REST endpoint, including the `/jwt-auth/v1` compatibility routes, so administrators can validate JWT flows alongside the existing GN and MLM examples.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.60
+ * Version:           0.3.61
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.60' );
+define( 'TCN_PLATFORM_VERSION', '0.3.61' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- introduce a shared JWT token service and reuse it from both the jwt-auth compatibility routes and the password login API
- issue JWT api_tokens from `/wp-json/gn/v1/login` while keeping hashed transients for validation and rate limiting
- bump the plugin version to 0.3.61 and document the restored JWT behaviour in the readme and docs

## Testing
- `php -l includes/Auth/JwtTokenService.php`
- `php -l includes/Auth/JwtAuthEndpoints.php`
- `php -l includes/Auth/PasswordLoginService.php`


------
https://chatgpt.com/codex/tasks/task_e_68e4f189c68483279b7f88ac7e2923ca