### PR TITLE
Prevent recursive REST auth errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.62
+- Prevent recursive authorization status lookups from exhausting PHP memory when REST requests include missing or malformed bearer tokens.
+
 ### 0.3.61
 - Restore JWT responses for `/wp-json/gn/v1/login` so mobile and third-party clients receive signed bearer tokens again.
 - Refactor the shared JWT helpers into a reusable service consumed by both the password login API and the `/jwt-auth/v1` compatibility routes.

--- a/includes/Auth/TokenAuthenticator.php
+++ b/includes/Auth/TokenAuthenticator.php
@@ -143,10 +143,9 @@ class TokenAuthenticator {
     protected function extract_token_from_header( string $header ) {
         if ( ! preg_match( '/Bearer\s+(.*)$/i', $header, $matches ) ) {
             if ( ! $this->should_log_non_bearer_header( $header ) ) {
-                return new WP_Error(
+                return $this->create_auth_error(
                     'tcn_rest_invalid_token',
-                    __( 'The provided authentication token is invalid.', 'tcnapp-connector' ),
-                    array( 'status' => rest_authorization_required_code() )
+                    __( 'The provided authentication token is invalid.', 'tcnapp-connector' )
                 );
             }
 
@@ -155,10 +154,9 @@ class TokenAuthenticator {
                 array( 'raw_header_preview' => $this->mask_string( $header ) )
             );
 
-            return new WP_Error(
+            return $this->create_auth_error(
                 'tcn_rest_invalid_token',
-                __( 'The provided authentication token is invalid.', 'tcnapp-connector' ),
-                array( 'status' => rest_authorization_required_code() )
+                __( 'The provided authentication token is invalid.', 'tcnapp-connector' )
             );
         }
 
@@ -166,10 +164,9 @@ class TokenAuthenticator {
         if ( '' === $token ) {
             $this->log_debug( 'authenticate_request extracted empty token' );
 
-            return new WP_Error(
+            return $this->create_auth_error(
                 'tcn_rest_invalid_token',
-                __( 'The provided authentication token is invalid.', 'tcnapp-connector' ),
-                array( 'status' => rest_authorization_required_code() )
+                __( 'The provided authentication token is invalid.', 'tcnapp-connector' )
             );
         }
 
@@ -212,10 +209,9 @@ class TokenAuthenticator {
         if ( ! class_exists( PasswordLoginService::class ) ) {
             $this->log_debug( 'authenticate_request PasswordLoginService class missing' );
 
-            return new WP_Error(
+            return $this->create_auth_error(
                 'tcn_rest_invalid_token',
-                __( 'The provided authentication token is invalid.', 'tcnapp-connector' ),
-                array( 'status' => rest_authorization_required_code() )
+                __( 'The provided authentication token is invalid.', 'tcnapp-connector' )
             );
         }
 
@@ -228,10 +224,9 @@ class TokenAuthenticator {
             $payload    = $this->get_api_token_payload( $token_hash );
 
             if ( false === $payload ) {
-                return new WP_Error(
+                return $this->create_auth_error(
                     'tcn_rest_token_expired',
-                    __( 'The authentication token has expired or is invalid.', 'tcnapp-connector' ),
-                    array( 'status' => rest_authorization_required_code() )
+                    __( 'The authentication token has expired or is invalid.', 'tcnapp-connector' )
                 );
             }
         }
@@ -247,10 +242,9 @@ class TokenAuthenticator {
                 )
             );
 
-            return new WP_Error(
+            return $this->create_auth_error(
                 'tcn_rest_token_expired',
-                __( 'The authentication token has expired or is invalid.', 'tcnapp-connector' ),
-                array( 'status' => rest_authorization_required_code() )
+                __( 'The authentication token has expired or is invalid.', 'tcnapp-connector' )
             );
         }
 
@@ -374,5 +368,43 @@ class TokenAuthenticator {
         }
 
         return substr( $value, 0, 4 ) . '...' . substr( $value, -4 );
+    }
+
+    /**
+     * Create a REST authentication error without triggering recursive status lookups.
+     */
+    protected function create_auth_error( string $code, string $message ): WP_Error {
+        return new WP_Error(
+            $code,
+            $message,
+            array( 'status' => $this->get_authorization_error_status() )
+        );
+    }
+
+    /**
+     * Resolve the authorization error status code with recursion protection.
+     */
+    protected function get_authorization_error_status(): int {
+        static $cached_status = null;
+
+        if ( function_exists( 'doing_filter' ) && doing_filter( 'determine_current_user' ) ) {
+            return null !== $cached_status ? $cached_status : 401;
+        }
+
+        if ( null === $cached_status ) {
+            $status = 401;
+
+            if ( function_exists( 'rest_authorization_required_code' ) ) {
+                $status = (int) rest_authorization_required_code();
+            }
+
+            if ( $status < 400 ) {
+                $status = 401;
+            }
+
+            $cached_status = $status;
+        }
+
+        return null !== $cached_status ? $cached_status : 401;
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.61
+Stable tag: 0.3.62
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.62 =
+* Prevent recursive authorization status lookups from exhausting PHP memory when bearer tokens are missing or malformed.
+
 = 0.3.61 =
 * Restore JWT responses for `/wp-json/gn/v1/login` so mobile clients once again receive signed bearer tokens alongside password reset and profile flows.
 * Share the JWT encoder/decoder with the `/jwt-auth/v1` compatibility endpoints to keep refresh and validate behaviour aligned.

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.61
+ * Version:           0.3.62
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.61' );
+define( 'TCN_PLATFORM_VERSION', '0.3.62' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/tests/TokenAuthenticatorTest.php
+++ b/tests/TokenAuthenticatorTest.php
@@ -87,6 +87,16 @@ final class TokenAuthenticatorTest extends TestCase {
         $this->assertContains( md5( 'server-token' ), $authenticator->received_token_hashes );
     }
 
+    public function test_determine_current_user_ignores_non_bearer_header(): void {
+        $_SERVER['HTTP_AUTHORIZATION'] = 'Basic ZGVtbzp0ZXN0';
+
+        $authenticator = $this->create_authenticator_expectation( 'unused-token' );
+
+        $result = $authenticator->determine_current_user( 0 );
+
+        $this->assertSame( 0, $result );
+    }
+
     private function create_authenticator_expectation( string $expected_token ): TokenAuthenticator {
         return new class( $expected_token ) extends TokenAuthenticator {
             /**


### PR DESCRIPTION
## Summary
- avoid recursive calls to `rest_authorization_required_code()` when resolving token authentication errors to stop PHP memory exhaustion
- add regression coverage for non-bearer authorization headers and update docs for version 0.3.62
- bump the plugin version metadata and changelog entries

## Testing
- php -l includes/Auth/TokenAuthenticator.php
- php -l tests/TokenAuthenticatorTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e4fee6d86883279116842a07ce435a