### PR TITLE
Ensure login endpoint always returns token string

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.63
+- Guarantee `/wp-json/gn/v1/login` issues a non-empty token string even if custom filters attempt to return invalid data.
+
 ### 0.3.62
 - Prevent recursive authorization status lookups from exhausting PHP memory when REST requests include missing or malformed bearer tokens.
 

--- a/includes/Auth/PasswordLoginService.php
+++ b/includes/Auth/PasswordLoginService.php
@@ -555,7 +555,19 @@ class PasswordLoginService {
     protected function issue_login_token( int $user_id ): array {
         $lifetime = apply_filters( 'gn_password_api_login_token_lifetime', (int) $this->settings['token_lifetime'], $user_id );
         $lifetime = max( WEEK_IN_SECONDS, $lifetime );
-        $token    = apply_filters( 'gn_password_api_issue_login_token', wp_generate_password( 48, false ), $user_id, $lifetime );
+
+        $generated = wp_generate_password( 48, false );
+        $token     = apply_filters( 'gn_password_api_issue_login_token', $generated, $user_id, $lifetime );
+
+        if ( ! is_string( $token ) ) {
+            $token = '';
+        }
+
+        $token = trim( $token );
+
+        if ( '' === $token ) {
+            $token = wp_generate_password( 48, false );
+        }
 
         set_transient(
             $this->build_token_key( $token ),

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.62
+Stable tag: 0.3.63
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.63 =
+* Ensure `/wp-json/gn/v1/login` always returns a non-empty token string even when custom filters provide invalid data.
+
 = 0.3.62 =
 * Prevent recursive authorization status lookups from exhausting PHP memory when bearer tokens are missing or malformed.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.62
+ * Version:           0.3.63
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.62' );
+define( 'TCN_PLATFORM_VERSION', '0.3.63' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- ensure the password login service replaces invalid filter output with a freshly generated token string before responding
- bump the plugin version to 0.3.63 and document the release in both readme files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5051a752483278be20ffd1aa77ae4