### PR TITLE
Handle REST avatar uploads via request file params

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.64
+- Accept avatar uploads from REST requests using parsed file parameters before falling back to PHP superglobals.
+
 ### 0.3.63
 - Guarantee `/wp-json/gn/v1/login` issues a non-empty token string even if custom filters attempt to return invalid data.
 

--- a/includes/Rest/ProfileEndpoints.php
+++ b/includes/Rest/ProfileEndpoints.php
@@ -138,11 +138,20 @@ class ProfileEndpoints {
             $user_id = get_current_user_id();
         }
 
+        $files = array();
+        if ( method_exists( $request, 'get_file_params' ) ) {
+            $files = (array) $request->get_file_params();
+        }
+
+        if ( empty( $files['avatar'] ) && isset( $_FILES['avatar'] ) ) {
+            $files['avatar'] = $_FILES['avatar'];
+        }
+
         $this->log_debug(
             'handle_avatar_upload invoked',
             array(
                 'resolved_user_id' => $user_id,
-                'files_present'    => isset( $_FILES['avatar'] ),
+                'files_present'    => isset( $files['avatar'] ),
             )
         );
 
@@ -156,7 +165,7 @@ class ProfileEndpoints {
             );
         }
 
-        if ( empty( $_FILES['avatar'] ) ) {
+        if ( empty( $files['avatar'] ) ) {
             $this->log_debug( 'handle_avatar_upload missing avatar file data' );
 
             return new WP_Error(
@@ -166,7 +175,22 @@ class ProfileEndpoints {
             );
         }
 
-        $file = $_FILES['avatar'];
+        $file = $files['avatar'];
+
+        if ( ! is_array( $file ) ) {
+            $this->log_debug(
+                'handle_avatar_upload received unexpected file payload',
+                array(
+                    'file_type' => gettype( $file ),
+                )
+            );
+
+            return new WP_Error(
+                'tcn_avatar_missing',
+                __( 'Upload an image file using the avatar field.', 'tcnapp-connector' ),
+                array( 'status' => 400 )
+            );
+        }
 
         if ( ! isset( $file['tmp_name'] ) || '' === $file['tmp_name'] ) {
             $this->log_debug(

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.63
+Stable tag: 0.3.64
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.64 =
+* Accept avatar uploads from REST requests using parsed file parameters before falling back to PHP superglobals.
+
 = 0.3.63 =
 * Ensure `/wp-json/gn/v1/login` always returns a non-empty token string even when custom filters provide invalid data.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.63
+ * Version:           0.3.64
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.63' );
+define( 'TCN_PLATFORM_VERSION', '0.3.64' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- accept avatar uploads from the REST request's parsed file parameters before falling back to the PHP superglobal
- guard against unexpected file payload structures when processing avatar uploads
- bump the plugin version and changelog for 0.3.64

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e563ccf29c832796eac62872559054