### PR TITLE
Gracefully handle missing REST request attribute helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.65
+- Avoid fatals on legacy WordPress versions by falling back to REST request parameters when attribute helpers are unavailable.
+
 ### 0.3.64
 - Accept avatar uploads from REST requests using parsed file parameters before falling back to PHP superglobals.
 

--- a/includes/Rest/ProfileEndpoints.php
+++ b/includes/Rest/ProfileEndpoints.php
@@ -92,7 +92,11 @@ class ProfileEndpoints {
             );
         }
 
-        $request->set_attribute( 'tcn_authenticated_user_id', $user_id );
+        if ( method_exists( $request, 'set_attribute' ) ) {
+            $request->set_attribute( 'tcn_authenticated_user_id', $user_id );
+        } else {
+            $request->set_param( 'tcn_authenticated_user_id', $user_id );
+        }
 
         if ( current_user_can( 'upload_files' ) ) {
             $this->log_debug(
@@ -132,7 +136,11 @@ class ProfileEndpoints {
      * Handle the avatar upload and return the updated user payload.
      */
     public function handle_avatar_upload( WP_REST_Request $request ) {
-        $user_id = (int) $request->get_attribute( 'tcn_authenticated_user_id' );
+        if ( method_exists( $request, 'get_attribute' ) ) {
+            $user_id = (int) $request->get_attribute( 'tcn_authenticated_user_id' );
+        } else {
+            $user_id = (int) $request->get_param( 'tcn_authenticated_user_id' );
+        }
 
         if ( $user_id <= 0 ) {
             $user_id = get_current_user_id();

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.64
+Stable tag: 0.3.65
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.65 =
+* Prevent fatal errors on older WordPress versions by falling back to REST request parameters when request attribute helpers are missing.
+
 = 0.3.64 =
 * Accept avatar uploads from REST requests using parsed file parameters before falling back to PHP superglobals.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.64
+ * Version:           0.3.65
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.64' );
+define( 'TCN_PLATFORM_VERSION', '0.3.65' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- fall back to REST request parameters when attribute helper methods are unavailable
- bump the plugin version to 0.3.65 and document the compatibility fix in both readme files

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e565e6df448327ae0a23c7f68c9023