### PR TITLE
Add Simple Local Avatars compatibility

### DIFF
--- a/docs/TCN_PLATFORM_REFERENCE.md
+++ b/docs/TCN_PLATFORM_REFERENCE.md
@@ -141,7 +141,8 @@ The profile endpoints let authenticated members update their avatar through the 
 * **Purpose:** Upload an image file, store it in the Media Library, attach it to the current user, and return the updated `/wp/v2/users/me` payload.
 * **Authentication:** `rest_require_login` equivalent – cookie session, `X-WP-Nonce`, or bearer token via the `TokenAuthenticator`.
 * **Request:** `multipart/form-data` with an `avatar` file field. Optional query/body attributes (`user_id`, `id`, `user`) are normalised to ensure users can only target their own profile.
-* **Processing:** Validates upload errors, file type (`image/*`), inserts an attachment, generates image sizes, stores `_gn_profile_avatar_id`, `_gn_profile_avatar_urls`, and `simple_local_avatar` meta, then clears the user cache.【F:includes/Rest/ProfileEndpoints.php†L52-L287】
+* **Processing:** Validates upload errors, file type (`image/*`), inserts an attachment, generates image sizes, stores `_gn_profile_avatar_id`, `_gn_profile_avatar_urls`, and `simple_local_avatar` meta, then clears the user cache.【F:includes/Rest/ProfileEndpoints.php†L52-L338】
+* **Compatibility:** Syncs metadata expected by the Simple Local Avatars plugin so uploads made via `/gn/v1/profile/avatar` stay visible in its admin UI and vice versa; REST payloads also respect avatars set directly through that plugin.【F:includes/Rest/ProfileEndpoints.php†L288-L520】
 * **Success response:** REST representation of `/wp/v2/users/me` including merged `avatar_urls` for the generated sizes.【F:includes/Rest/ProfileEndpoints.php†L288-L338】【F:includes/Rest/ProfileEndpoints.php†L400-L427】
 * **Failure cases:**
   * Unauthenticated → `401 tcn_rest_unauthorized`.

--- a/includes/Rest/ProfileEndpoints.php
+++ b/includes/Rest/ProfileEndpoints.php
@@ -343,14 +343,12 @@ class ProfileEndpoints {
 
         update_user_meta( $user_id, '_gn_profile_avatar_id', $attachment_id );
         update_user_meta( $user_id, '_gn_profile_avatar_urls', $avatar_urls );
-        update_user_meta(
-            $user_id,
-            'simple_local_avatar',
-            array(
-                'full'     => isset( $avatar_urls['full'] ) ? $avatar_urls['full'] : wp_get_attachment_url( $attachment_id ),
-                'media_id' => $attachment_id,
-            )
-        );
+
+        $simple_local_avatar = $this->build_simple_local_avatar_meta( $attachment_id, $avatar_urls );
+
+        if ( ! empty( $simple_local_avatar ) ) {
+            update_user_meta( $user_id, 'simple_local_avatar', $simple_local_avatar );
+        }
 
         clean_user_cache( $user_id );
 
@@ -386,12 +384,28 @@ class ProfileEndpoints {
             return $response;
         }
 
-        $avatar_id = (int) get_user_meta( $user->ID, '_gn_profile_avatar_id', true );
-        if ( $avatar_id <= 0 ) {
-            return $response;
+        $avatar_id   = (int) get_user_meta( $user->ID, '_gn_profile_avatar_id', true );
+        $avatar_urls = array();
+
+        if ( $avatar_id > 0 ) {
+            $avatar_urls = $this->prepare_avatar_urls( $avatar_id );
         }
 
-        $avatar_urls = $this->prepare_avatar_urls( $avatar_id );
+        if ( empty( $avatar_urls ) ) {
+            $simple_avatar = get_user_meta( $user->ID, 'simple_local_avatar', true );
+            $avatar_urls   = $this->normalise_simple_local_avatar_urls( $simple_avatar );
+
+            if ( $avatar_id <= 0 && is_array( $simple_avatar ) && ! empty( $simple_avatar['media_id'] ) ) {
+                $avatar_id   = (int) $simple_avatar['media_id'];
+                $avatar_urls = $this->prepare_avatar_urls( $avatar_id );
+            }
+
+            if ( $avatar_id > 0 && ! empty( $avatar_urls ) ) {
+                update_user_meta( $user->ID, '_gn_profile_avatar_id', $avatar_id );
+                update_user_meta( $user->ID, '_gn_profile_avatar_urls', $avatar_urls );
+            }
+        }
+
         if ( empty( $avatar_urls ) ) {
             return $response;
         }
@@ -450,19 +464,134 @@ class ProfileEndpoints {
      * Prepare avatar URLs for the response payload.
      */
     protected function prepare_avatar_urls( int $attachment_id ): array {
+        if ( $attachment_id <= 0 ) {
+            return array();
+        }
+
         $urls  = array();
         $sizes = array( 24, 48, 96, 192, 256 );
 
         foreach ( $sizes as $size ) {
             $image = wp_get_attachment_image_src( $attachment_id, array( $size, $size ) );
+
             if ( is_array( $image ) && ! empty( $image[0] ) ) {
                 $urls[ (string) $size ] = $image[0];
             }
         }
 
         $full = wp_get_attachment_url( $attachment_id );
+
         if ( $full ) {
             $urls['full'] = $full;
+        }
+
+        return $urls;
+    }
+
+    /**
+     * Build metadata compatible with the Simple Local Avatars plugin.
+     */
+    protected function build_simple_local_avatar_meta( int $attachment_id, array $avatar_urls ): array {
+        if ( $attachment_id <= 0 || empty( $avatar_urls ) ) {
+            return array();
+        }
+
+        $meta = array(
+            'media_id' => $attachment_id,
+        );
+
+        foreach ( $avatar_urls as $size => $url ) {
+            if ( 'media_id' === $size ) {
+                continue;
+            }
+
+            if ( ! is_string( $size ) ) {
+                $size = (string) $size;
+            }
+
+            if ( ! is_string( $url ) || '' === $url ) {
+                continue;
+            }
+
+            $meta[ $size ] = $url;
+
+            if ( substr( $size, -5 ) === '_path' ) {
+                continue;
+            }
+
+            if ( 'full' === $size ) {
+                continue;
+            }
+
+            $path_key = $size . '_path';
+
+            if ( isset( $avatar_urls[ $path_key ] ) && is_string( $avatar_urls[ $path_key ] ) ) {
+                $meta[ $path_key ] = $avatar_urls[ $path_key ];
+                continue;
+            }
+
+            $intermediate = image_get_intermediate_size( $attachment_id, is_numeric( $size ) ? array( (int) $size, (int) $size ) : $size );
+
+            if ( is_array( $intermediate ) && ! empty( $intermediate['file'] ) ) {
+                $full_path = get_attached_file( $attachment_id );
+
+                if ( $full_path ) {
+                    $meta[ $path_key ] = path_join( dirname( $full_path ), $intermediate['file'] );
+                }
+            }
+        }
+
+        if ( ! isset( $meta['full'] ) ) {
+            $full = wp_get_attachment_url( $attachment_id );
+
+            if ( $full ) {
+                $meta['full'] = $full;
+            }
+        }
+
+        if ( ! isset( $meta['full_path'] ) ) {
+            $full_path = get_attached_file( $attachment_id );
+
+            if ( $full_path ) {
+                $meta['full_path'] = $full_path;
+            }
+        }
+
+        return $meta;
+    }
+
+    /**
+     * Normalise metadata saved by the Simple Local Avatars plugin into a URL map.
+     *
+     * @param mixed $meta Stored user meta value.
+     */
+    protected function normalise_simple_local_avatar_urls( $meta ): array {
+        if ( ! is_array( $meta ) || empty( $meta ) ) {
+            return array();
+        }
+
+        $urls = array();
+
+        foreach ( $meta as $key => $value ) {
+            if ( ! is_string( $key ) ) {
+                $key = (string) $key;
+            }
+
+            if ( 'media_id' === $key ) {
+                continue;
+            }
+
+            if ( is_string( $value ) && '' !== $value ) {
+                $urls[ $key ] = $value;
+            }
+        }
+
+        if ( empty( $urls ) && ! empty( $meta['media_id'] ) ) {
+            $attachment_id = (int) $meta['media_id'];
+
+            if ( $attachment_id > 0 ) {
+                return $this->prepare_avatar_urls( $attachment_id );
+            }
         }
 
         return $urls;
@@ -481,17 +610,31 @@ class ProfileEndpoints {
         }
 
         $attachment_id = (int) get_user_meta( $user_id, '_gn_profile_avatar_id', true );
+        $urls          = array();
 
-        if ( $attachment_id <= 0 ) {
-            return '';
+        if ( $attachment_id > 0 ) {
+            $urls = get_user_meta( $user_id, '_gn_profile_avatar_urls', true );
+
+            if ( ! is_array( $urls ) || empty( $urls ) ) {
+                $urls = $this->prepare_avatar_urls( $attachment_id );
+
+                if ( ! empty( $urls ) ) {
+                    update_user_meta( $user_id, '_gn_profile_avatar_urls', $urls );
+                }
+            }
         }
 
-        $urls = get_user_meta( $user_id, '_gn_profile_avatar_urls', true );
+        if ( empty( $urls ) ) {
+            $simple_avatar = get_user_meta( $user_id, 'simple_local_avatar', true );
+            $urls          = $this->normalise_simple_local_avatar_urls( $simple_avatar );
 
-        if ( ! is_array( $urls ) || empty( $urls ) ) {
-            $urls = $this->prepare_avatar_urls( $attachment_id );
+            if ( $attachment_id <= 0 && is_array( $simple_avatar ) && ! empty( $simple_avatar['media_id'] ) ) {
+                $attachment_id = (int) $simple_avatar['media_id'];
+                $urls          = $this->prepare_avatar_urls( $attachment_id );
+            }
 
-            if ( ! empty( $urls ) ) {
+            if ( $attachment_id > 0 && ! empty( $urls ) ) {
+                update_user_meta( $user_id, '_gn_profile_avatar_id', $attachment_id );
                 update_user_meta( $user_id, '_gn_profile_avatar_urls', $urls );
             }
         }
@@ -520,7 +663,11 @@ class ProfileEndpoints {
             return $this->maybe_apply_avatar_scheme( $urls['full'], $args );
         }
 
-        foreach ( $urls as $candidate ) {
+        foreach ( $urls as $key => $candidate ) {
+            if ( 'media_id' === $key ) {
+                continue;
+            }
+
             if ( is_string( $candidate ) && '' !== $candidate ) {
                 return $this->maybe_apply_avatar_scheme( $candidate, $args );
             }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.66
+Stable tag: 0.3.67
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,10 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.67 =
+* Honour avatars provided by the Simple Local Avatars plugin across REST payloads and `get_avatar*` filters, falling back to its metadata when `_gn_profile_avatar_id` is missing.
+* Store Simple Local Avatars compatible metadata whenever profile photos are uploaded through `/gn/v1/profile/avatar` so the admin UI and other plugins stay in sync.
+
 = 0.3.65 =
 * Prevent fatal errors on older WordPress versions by falling back to REST request parameters when request attribute helpers are missing.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.66
+ * Version:           0.3.67
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.66' );
+define( 'TCN_PLATFORM_VERSION', '0.3.67' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- sync avatar uploads with the metadata that Simple Local Avatars expects so both plugins stay aligned
- honour avatars managed by Simple Local Avatars when filtering REST responses and get_avatar lookups
- document the compatibility and bump the plugin version to 0.3.67

## Testing
- php -l includes/Rest/ProfileEndpoints.php

------
https://chatgpt.com/codex/tasks/task_e_68e57255083c8327b8ecf16074341fd4