### PR TITLE
Bump plugin version to 0.3.68

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.67
+Stable tag: 0.3.68
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,7 +101,7 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
-= 0.3.67 =
+= 0.3.68 =
 * Honour avatars provided by the Simple Local Avatars plugin across REST payloads and `get_avatar*` filters, falling back to its metadata when `_gn_profile_avatar_id` is missing.
 * Store Simple Local Avatars compatible metadata whenever profile photos are uploaded through `/gn/v1/profile/avatar` so the admin UI and other plugins stay in sync.
 

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.67
+ * Version:           0.3.68
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.67' );
+define( 'TCN_PLATFORM_VERSION', '0.3.68' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- bump the plugin header version and shared constant to 0.3.68
- update the readme stable tag and changelog heading to match the new release

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e57cc250208327acb28154f9a1c15b