### PR TITLE
Enforce HTTPS for avatar uploads and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.70
+- Enforce the same HTTPS checks used by the login and change password endpoints when uploading avatars, while still honouring the `gn_password_api_allow_dev_http` development override filter.【F:includes/Rest/ProfileEndpoints.php†L49-L120】【F:includes/Rest/ProfileEndpoints.php†L520-L537】
+- When avatar uploads rely on bearer tokens, set the current user so Media Library operations run under the authenticated account.【F:includes/Rest/ProfileEndpoints.php†L95-L118】
+
 ### 0.3.69
 - Allow `/gn/v1/profile/avatar` requests to supply an `avatar_url` so remote images are downloaded, validated, and stored in the Media Library alongside traditional file uploads.【F:includes/Rest/ProfileEndpoints.php†L150-L360】
 - Mirror WP User Avatar metadata when profile photos are updated and honour avatars created via that plugin when building REST payloads or `get_avatar` responses.【F:includes/Rest/ProfileEndpoints.php†L362-L520】

--- a/includes/Rest/ProfileEndpoints.php
+++ b/includes/Rest/ProfileEndpoints.php
@@ -2,6 +2,7 @@
 namespace TCN\Platform\Rest;
 
 use TCN\Platform\Auth\TokenAuthenticator;
+use TCN\Platform\Support\Options;
 use WP_Comment;
 use WP_Error;
 use WP_Post;
@@ -16,8 +17,14 @@ class ProfileEndpoints {
      */
     protected $token_authenticator;
 
-    public function __construct( ?TokenAuthenticator $token_authenticator = null ) {
+    /**
+     * @var array<string, mixed>
+     */
+    protected $login_settings;
+
+    public function __construct( ?TokenAuthenticator $token_authenticator = null, array $login_settings = array() ) {
         $this->token_authenticator = $token_authenticator;
+        $this->login_settings      = ! empty( $login_settings ) ? $login_settings : Options::get_login_settings();
     }
 
     /**
@@ -52,6 +59,11 @@ class ProfileEndpoints {
      * Ensure the requester is authenticated and can upload files.
      */
     public function permissions_check( WP_REST_Request $request ) {
+        $https = $this->maybe_enforce_https( $request );
+        if ( is_wp_error( $https ) ) {
+            return $https;
+        }
+
         $user_id = get_current_user_id();
 
         $this->log_debug(
@@ -132,6 +144,14 @@ class ProfileEndpoints {
                 __( 'You can only upload an avatar for your own profile.', 'tcnapp-connector' ),
                 array( 'status' => 403 )
             );
+        }
+
+        if ( $user_id > 0 && get_current_user_id() !== $user_id ) {
+            $user = get_user_by( 'id', $user_id );
+
+            if ( $user instanceof WP_User ) {
+                wp_set_current_user( $user_id );
+            }
         }
 
         return true;
@@ -768,6 +788,26 @@ class ProfileEndpoints {
         }
 
         return $this->token_authenticator->authenticate_request( $request );
+    }
+
+    /**
+     * Block non-HTTPS requests unless development overrides allow it.
+     *
+     * @return true|WP_Error
+     */
+    protected function maybe_enforce_https( WP_REST_Request $request ) {
+        $allow_dev = ! empty( $this->login_settings['allow_dev_http'] ) && defined( 'WP_DEBUG' ) && WP_DEBUG;
+        $allow_dev = apply_filters( 'gn_password_api_allow_dev_http', $allow_dev, $request );
+
+        if ( is_ssl() || $allow_dev ) {
+            return true;
+        }
+
+        return new WP_Error(
+            'gn_https_required',
+            __( 'HTTPS is required to access this endpoint.', 'tcnapp-connector' ),
+            array( 'status' => 403 )
+        );
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.69
+Stable tag: 0.3.70
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,10 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+= 0.3.70 =
+* Enforce HTTPS for `/gn/v1/profile/avatar` like the login and password change endpoints while still allowing `gn_password_api_allow_dev_http` overrides for local development.
+* Refresh authentication handling so bearer tokens on avatar uploads establish the current user before Media Library operations run.
+
 = 0.3.69 =
 * Allow `/gn/v1/profile/avatar` requests to supply an `avatar_url` so remote images are fetched, validated, and stored alongside traditional uploads.
 * Sync WP User Avatar metadata when profile photos change and honour avatars set via that plugin when building REST payloads or WordPress `get_avatar` responses.

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.69
+ * Version:           0.3.70
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.69' );
+define( 'TCN_PLATFORM_VERSION', '0.3.70' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- enforce HTTPS checks on the avatar upload endpoint using the same settings and filters as the login/password change flows
- set the current user when bearer tokens authenticate avatar uploads so media operations run under the correct account
- bump the plugin version to 0.3.70 and document the changes in the README and changelog

## Testing
- `php -l includes/Rest/ProfileEndpoints.php`


------
https://chatgpt.com/codex/tasks/task_e_68e582f0c0fc8327b0551d6c4138db95