### PR TITLE
Preserve avatar URL keys when merging REST responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.72
+- Preserve avatar URL size keys when merging stored values into REST responses so numeric indexes like `24`, `48`, and `96` stay aligned with WordPress core expectations.
+
 ### 0.3.71
 - Let `/gn/v1/profile/avatar` accept JSON payloads that either reference a remote `avatar_url` or include `avatar_base64` image data so mobile clients can bypass multipart uploads while keeping Media Library validation in place.【F:includes/Rest/ProfileEndpoints.php†L166-L320】【F:includes/Rest/ProfileEndpoints.php†L470-L612】
 

--- a/includes/Rest/ProfileEndpoints.php
+++ b/includes/Rest/ProfileEndpoints.php
@@ -904,7 +904,8 @@ class ProfileEndpoints {
         }
 
         $data = $response->get_data();
-        $data['avatar_urls'] = array_merge( isset( $data['avatar_urls'] ) && is_array( $data['avatar_urls'] ) ? $data['avatar_urls'] : array(), $avatar_urls );
+        $existing = ( isset( $data['avatar_urls'] ) && is_array( $data['avatar_urls'] ) ) ? $data['avatar_urls'] : array();
+        $data['avatar_urls'] = array_replace( $existing, $avatar_urls );
         $response->set_data( $data );
 
         return $response;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.71
+Stable tag: 0.3.72
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+
+= 0.3.72 =
+* Preserve avatar URL size keys when merging stored values into REST responses so numeric indexes like `24`, `48`, and `96` remain intact.
 
 = 0.3.71 =
 * Allow `/gn/v1/profile/avatar` to accept JSON payloads with either an `avatar_url` or base64 encoded image data so mobile clients can skip multipart form uploads.【F:includes/Rest/ProfileEndpoints.php†L166-L320】【F:includes/Rest/ProfileEndpoints.php†L470-L612】

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.71
+ * Version:           0.3.72
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'TCN_PLATFORM_VERSION', '0.3.71' );
+define( 'TCN_PLATFORM_VERSION', '0.3.72' );
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'TCN_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TCN_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- preserve existing avatar URL keys when enriching REST user responses to avoid numeric reindexing
- bump the plugin version to 0.3.72 and document the change in both readmes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e590859ec0832786eb66b24509c601