### PR TITLE
Allow login with email identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.96
+- Allow `/gn/v1/login` requests to authenticate with either a username or email identifier so mobile and smoke-test clients can submit whichever field they collect.
+
 ### 0.3.95
 - Maintenance: Bump the plugin version for the 0.3.95 release.
 

--- a/includes/Auth/PasswordLoginService.php
+++ b/includes/Auth/PasswordLoginService.php
@@ -304,6 +304,15 @@ class PasswordLoginService {
         $username = sanitize_text_field( $request->get_param( 'username' ) );
         $email    = sanitize_email( (string) $request->get_param( 'email' ) );
         $password = (string) $request->get_param( 'password' );
+
+        if ( '' === $email ) {
+            $username_as_email = sanitize_email( $username );
+
+            if ( '' !== $username_as_email ) {
+                $email    = $username_as_email;
+                $username = '';
+            }
+        }
         if ( empty( $password ) || ( empty( $username ) && empty( $email ) ) ) {
             return ErrorCodes::to_wp_error(
                 ErrorCodes::AUTH_LOGIN_MISSING_CREDENTIALS,

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.95
+Stable tag: 0.3.96
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+
+= 0.3.96 =
+* Allow `/gn/v1/login` requests to authenticate with either a username or email identifier so mobile and smoke-test clients can submit whichever field they collect.
 
 = 0.3.95 =
 * Maintenance: Bump the plugin version for the 0.3.95 release.

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.95
+ * Version:           0.3.96
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // The current plugin version is surfaced in multiple places (plugin header, constant, updater).
 // Keeping a single source of truth via this constant makes it trivial to reference and compare
 // versions throughout the codebase—for example when performing migrations.
-define( 'TCN_PLATFORM_VERSION', '0.3.95' );
+define( 'TCN_PLATFORM_VERSION', '0.3.96' );
 // The absolute path to this file is cached to avoid repeated calls to plugin_basename() and
 // to ensure other classes (e.g. the autoloader) can reliably resolve relative paths.
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );


### PR DESCRIPTION
## Summary
- allow the password login API to treat username submissions that look like email addresses as email logins so clients can send whichever identifier they store
- document the behaviour and bump the plugin version to 0.3.96

## Testing
- php -l includes/Auth/PasswordLoginService.php
- php -l tcnapp-connector.php

------
https://chatgpt.com/codex/tasks/task_e_68efc3676a0c8327b67e6c0f28a7b916