### PR TITLE
Allow JWT login via email and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.97
+- Treat the username parameter on the JWT compatibility `/token` endpoint as an email when appropriate so users can authenticate with either their email address or username alongside their password.
+
 ### 0.3.96
 - Allow `/gn/v1/login` requests to authenticate with either a username or email identifier so mobile and smoke-test clients can submit whichever field they collect.
 

--- a/includes/Auth/JwtAuthEndpoints.php
+++ b/includes/Auth/JwtAuthEndpoints.php
@@ -70,6 +70,15 @@ class JwtAuthEndpoints {
         $email    = sanitize_email( (string) $request->get_param( 'email' ) );
         $password = (string) $request->get_param( 'password' );
 
+        if ( '' === $email ) {
+            $username_as_email = sanitize_email( $username );
+
+            if ( '' !== $username_as_email ) {
+                $email    = $username_as_email;
+                $username = '';
+            }
+        }
+
         if ( '' === $password || ( '' === $username && '' === $email ) ) {
             return new WP_Error(
                 'jwt_auth_missing_credentials',

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.96
+Stable tag: 0.3.97
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+
+= 0.3.97 =
+* Allow the JWT compatibility `/token` endpoint to treat the provided username as an email when appropriate so users can log in using either their email address or their username alongside the password.
 
 = 0.3.96 =
 * Allow `/gn/v1/login` requests to authenticate with either a username or email identifier so mobile and smoke-test clients can submit whichever field they collect.

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.96
+ * Version:           0.3.97
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // The current plugin version is surfaced in multiple places (plugin header, constant, updater).
 // Keeping a single source of truth via this constant makes it trivial to reference and compare
 // versions throughout the codebase—for example when performing migrations.
-define( 'TCN_PLATFORM_VERSION', '0.3.96' );
+define( 'TCN_PLATFORM_VERSION', '0.3.97' );
 // The absolute path to this file is cached to avoid repeated calls to plugin_basename() and
 // to ensure other classes (e.g. the autoloader) can reliably resolve relative paths.
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );


### PR DESCRIPTION
## Summary
- allow the JWT compatibility token endpoint to treat username input as an email when appropriate so logins succeed with either identifier
- bump the plugin version metadata to 0.3.97 and document the change in the README files

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68efc8e6324083279638b35e4b32c6ee