### PR TITLE
Document React integration gaps and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.98
+- Document the current integration gaps between the React app and plugin endpoints so front-end updates can align payloads, routes, and field names with the server contract.
+
 ### 0.3.97
 - Treat the username parameter on the JWT compatibility `/token` endpoint as an email when appropriate so users can authenticate with either their email address or username alongside their password.
 

--- a/docs/tcnapp-plugin-misalignment.md
+++ b/docs/tcnapp-plugin-misalignment.md
@@ -1,0 +1,45 @@
+# TCNApp ↔︎ TCN Platform Integration Notes
+
+This guide summarises the integration mismatches observed between the React client ("TCNApp") and the WordPress plugin ("TCN Platform"), plus concrete adjustments to bring the two back in sync. Each section references the authoritative behaviour implemented inside the plugin so front-end changes can be prioritised accurately.
+
+## Token refresh endpoint
+
+* **React behaviour:** The app attempts to refresh bearer tokens via `/wp-json/gn/v1/token/refresh` and falls back to an older compatibility route.
+* **Plugin contract:** The compatibility layer exposes `/wp-json/jwt-auth/v1/token/refresh` for JWT clients while the Password Login API already handles refreshes internally.【F:includes/Auth/JwtAuthEndpoints.php†L19-L170】
+* **Fix:** Point the React `refreshToken` call at `/wp-json/jwt-auth/v1/token/refresh` and remove the unused legacy fallback logic so refresh attempts always hit the supported endpoint.
+
+## Password reset payloads
+
+* **React behaviour:** `requestPasswordReset` posts many redundant fields (`identifier`, `user_login`, `user_email`, etc.) and `resetPasswordWithCode` sends both identifier and email plus duplicated password keys.
+* **Plugin contract:** `/wp-json/gn/v1/forgot-password` only inspects `username` (treated as a username or email) and an optional `return_verification_code` flag, while `/wp-json/gn/v1/reset-password` expects `{ login, password, verification_code? | key? }` and rejects extra reset tokens.【F:includes/Auth/PasswordLoginService.php†L560-L659】
+* **Fix:** Send `{ login: identifier, return_verification_code: true }` when requesting a reset and `{ login: identifier, password: newPassword, verification_code: code }` (or `{ ..., key: resetKey }`) when confirming the reset.
+
+## Registration payload shape
+
+* **React behaviour:** Registration requests include WooCommerce order/customer payloads, a hard-coded `membership_tier`, and numerous unused metadata fields.
+* **Plugin contract:** `/wp-json/gn/v1/register` only validates `username`, `email`, `password`, optional `first_name`/`last_name`, `account_type`, and an optional `vendor_tier` slug when creating vendor accounts.【F:includes/Auth/PasswordLoginService.php†L432-L552】
+* **Fix:** Trim requests to the minimal shape—members: `{ username, email, password, first_name?, last_name?, account_type: "member", membership_plan? }`; vendors: `{ username, email, password, first_name?, last_name?, account_type: "vendor", vendor_tier }`.
+
+## Membership QR helpers
+
+* **React behaviour:** The client invokes `/wp-json/gn/v1/membership/qr` and `/wp-json/gn/v1/membership/qr/validate` for QR code flows.
+* **Plugin contract:** The plugin still ships QR endpoints via `MembershipQrEndpoints`, but they are legacy helpers layered on top of the newer membership plan + Stripe upgrade flows.【F:includes/Plugin.php†L18-L110】【F:includes/Rest/MembershipQrEndpoints.php†L1-L214】
+* **Fix:** Confirm whether the deployment relies on these QR routes. If not, disable the React QR helpers to avoid depending on endpoints that may be deprecated.
+
+## Discount transaction payloads
+
+* **React behaviour:** Transaction requests and history lookups use camelCase keys such as `grossAmount` and a `scope` query parameter.
+* **Plugin contract:** The discount endpoints accept snake_case fields (`gross_amount`, `discount_amount`, `net_amount`, `member_id`, `vendor_id`) and history filtering via explicit `member_id`/`vendor_id` query arguments.【F:includes/Rest/DiscountEndpoints.php†L26-L362】
+* **Fix:** Map camelCase variables to the documented snake_case names before posting and replace the `scope` parameter with `member_id` or `vendor_id` depending on the view being requested.
+
+## Membership service responses
+
+* **React behaviour:** Stripe onboarding flows expect camelCase fields like `requiresPayment` and `paymentIntentClientSecret`.
+* **Plugin contract:** Membership plan and Stripe responses expose snake_case keys—e.g. `requires_payment`, `publishable_key`, and raw Stripe intent objects—while still including a backwards-compatible `publishableKey` copy.【F:includes/Membership/MembershipModule.php†L384-L599】
+* **Fix:** Normalise plugin responses in the React service layer, converting snake_case to camelCase only after parsing.
+
+## Vendor promotion allowance
+
+* **React behaviour:** Vendor dashboards read a `promotionSummary` field from the vendor tier catalogue.
+* **Plugin contract:** Tiers expose a `promotion_allowance` string, with legacy `promotion_summary` support limited to internal formatting helpers.【F:includes/Rest/VendorEndpoints.php†L24-L120】
+* **Fix:** Adjust the React vendor service to consume `promotion_allowance` (mapping to a percentage or count as needed) instead of the non-existent `promotionSummary` key.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.97
+Stable tag: 0.3.98
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+
+= 0.3.98 =
+* Document the current integration gaps between the React client and plugin endpoints so front-end payloads and routing align with the server contract.
 
 = 0.3.97 =
 * Allow the JWT compatibility `/token` endpoint to treat the provided username as an email when appropriate so users can log in using either their email address or their username alongside the password.

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.97
+ * Version:           0.3.98
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // The current plugin version is surfaced in multiple places (plugin header, constant, updater).
 // Keeping a single source of truth via this constant makes it trivial to reference and compare
 // versions throughout the codebase—for example when performing migrations.
-define( 'TCN_PLATFORM_VERSION', '0.3.97' );
+define( 'TCN_PLATFORM_VERSION', '0.3.98' );
 // The absolute path to this file is cached to avoid repeated calls to plugin_basename() and
 // to ensure other classes (e.g. the autoloader) can reliably resolve relative paths.
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );


### PR DESCRIPTION
## Summary
- add an integration guide summarising the mismatches between the React client and the plugin’s REST contracts
- bump the plugin metadata to version 0.3.98 and record the release notes in both readme files

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68efd1c093dc8327906898147e2ef21b