### PR TITLE
Allow email usernames to pass login validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ The legacy class name `GN_Password_Login_API` is aliased to the new service for 
 
 ## 📝 Release Notes
 
+### 0.3.99
+- Allow `/gn/v1/login` calls that send the registered email for both the username and email fields to authenticate successfully by treating matching emails as satisfying the username requirement and continuing to return the expected token payload.
+
 ### 0.3.98
 - Document the current integration gaps between the React app and plugin endpoints so front-end updates can align payloads, routes, and field names with the server contract.
 

--- a/includes/Auth/PasswordLoginService.php
+++ b/includes/Auth/PasswordLoginService.php
@@ -947,6 +947,15 @@ class PasswordLoginService {
         $expected_email    = trim( $expected_email );
 
         $login_matches = '' === $expected_username ? true : 0 === strcasecmp( $user->user_login, $expected_username );
+
+        if ( ! $login_matches && '' !== $expected_username ) {
+            if ( 0 === strcasecmp( $user->user_email, $expected_username ) ) {
+                $login_matches = true;
+            } elseif ( '' !== $expected_email && 0 === strcasecmp( $expected_username, $expected_email ) && 0 === strcasecmp( $user->user_email, $expected_email ) ) {
+                $login_matches = true;
+            }
+        }
+
         $email_matches = '' === $expected_email ? true : 0 === strcasecmp( $user->user_email, $expected_email );
 
         return $login_matches && $email_matches;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, mlm, memberships, commissions, genealogy, authentication
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.3.98
+Stable tag: 0.3.99
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,9 @@ The REST endpoints stop registering, but existing options remain stored. Re-enab
 Activation seeds hidden products for the Blue, Gold, Platinum, and Black tiers (if missing) and keeps their pricing/categories synced with admin defaults. Use the **TCN Membership Level** drop-down on other products to link them to tiers manually.
 
 == Changelog ==
+
+= 0.3.99 =
+* Allow `/gn/v1/login` requests that provide the account email for both the username and email parameters to authenticate successfully and return the expected token payload by treating matching emails as satisfying the username check.
 
 = 0.3.98 =
 * Document the current integration gaps between the React client and plugin endpoints so front-end payloads and routing align with the server contract.

--- a/tcnapp-connector.php
+++ b/tcnapp-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name:       TCN Platform
  * Plugin URI:        https://www.georgenicolaou.me/plugins/tcn-platform
  * Description:       Unified membership, MLM, and password-login API services for WooCommerce-powered TCN deployments.
- * Version:           0.3.98
+ * Version:           0.3.99
  * Author:            George Nicolaou
  * Author URI:        https://www.georgenicolaou.me/
  * License:           GPL-2.0+
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // The current plugin version is surfaced in multiple places (plugin header, constant, updater).
 // Keeping a single source of truth via this constant makes it trivial to reference and compare
 // versions throughout the codebase—for example when performing migrations.
-define( 'TCN_PLATFORM_VERSION', '0.3.98' );
+define( 'TCN_PLATFORM_VERSION', '0.3.99' );
 // The absolute path to this file is cached to avoid repeated calls to plugin_basename() and
 // to ensure other classes (e.g. the autoloader) can reliably resolve relative paths.
 define( 'TCN_PLATFORM_PLUGIN_FILE', __FILE__ );

--- a/tests/PasswordLoginServiceTest.php
+++ b/tests/PasswordLoginServiceTest.php
@@ -4,7 +4,280 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use TCN\Platform\Auth\PasswordLoginService;
 
+require_once __DIR__ . '/../includes/Support/ErrorCodes.php';
+require_once __DIR__ . '/../includes/Support/Accounts.php';
 require_once __DIR__ . '/../includes/Auth/PasswordLoginService.php';
+
+if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+    define( 'HOUR_IN_SECONDS', 3600 );
+}
+
+if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+    define( 'DAY_IN_SECONDS', 86400 );
+}
+
+if ( ! defined( 'WEEK_IN_SECONDS' ) ) {
+    define( 'WEEK_IN_SECONDS', 7 * DAY_IN_SECONDS );
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+    function sanitize_key( $key ) {
+        $key = strtolower( (string) $key );
+
+        return preg_replace( '/[^a-z0-9_]/', '', $key );
+    }
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+    function sanitize_text_field( $value ) {
+        return trim( (string) $value );
+    }
+}
+
+if ( ! function_exists( 'sanitize_email' ) ) {
+    function sanitize_email( $value ) {
+        $value = trim( (string) $value );
+
+        return strtolower( $value );
+    }
+}
+
+if ( ! function_exists( 'sanitize_user' ) ) {
+    function sanitize_user( $value ) {
+        return trim( (string) $value );
+    }
+}
+
+if ( ! function_exists( 'is_email' ) ) {
+    function is_email( $value ) {
+        $value = trim( (string) $value );
+
+        return '' !== $value && false !== strpos( $value, '@' );
+    }
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+    function apply_filters( $hook, $value ) {
+        return $value;
+    }
+}
+
+if ( ! function_exists( 'is_ssl' ) ) {
+    function is_ssl() {
+        return true;
+    }
+}
+
+if ( ! function_exists( 'add_query_arg' ) ) {
+    function add_query_arg( array $args, string $url ) {
+        $separator = false === strpos( $url, '?' ) ? '?' : '&';
+
+        return $url . $separator . http_build_query( $args, '', '&', PHP_QUERY_RFC3986 );
+    }
+}
+
+if ( ! function_exists( 'wp_login_url' ) ) {
+    function wp_login_url() {
+        return 'https://example.com/wp-login.php';
+    }
+}
+
+if ( ! function_exists( 'wp_authenticate' ) ) {
+    function wp_authenticate( $login, $password ) {
+        $login = (string) $login;
+        $users = $GLOBALS['tcn_test_users'] ?? array();
+
+        foreach ( $users as $user ) {
+            if ( ! $user instanceof WP_User ) {
+                continue;
+            }
+
+            if ( 0 === strcasecmp( $user->user_login, $login ) || 0 === strcasecmp( $user->user_email, $login ) ) {
+                if ( $password === $user->user_pass ) {
+                    return $user;
+                }
+
+                break;
+            }
+        }
+
+        return new WP_Error( 'invalid_credentials', 'Invalid credentials.' );
+    }
+}
+
+if ( ! function_exists( 'wp_check_password' ) ) {
+    function wp_check_password( $password, $hash, $user_id = 0 ) {
+        return $password === $hash;
+    }
+}
+
+if ( ! function_exists( 'get_user_by' ) ) {
+    function get_user_by( $field, $value ) {
+        $value = (string) $value;
+        $users = $GLOBALS['tcn_test_users'] ?? array();
+
+        foreach ( $users as $user ) {
+            if ( ! $user instanceof WP_User ) {
+                continue;
+            }
+
+            if ( 'email' === strtolower( (string) $field ) && 0 === strcasecmp( $user->user_email, $value ) ) {
+                return $user;
+            }
+
+            if ( 'login' === strtolower( (string) $field ) && 0 === strcasecmp( $user->user_login, $value ) ) {
+                return $user;
+            }
+
+            if ( 'id' === strtolower( (string) $field ) && (int) $user->ID === (int) $value ) {
+                return $user;
+            }
+        }
+
+        return false;
+    }
+}
+
+if ( ! function_exists( 'update_user_meta' ) ) {
+    function update_user_meta( $user_id, $meta_key, $meta_value ) {
+        if ( ! isset( $GLOBALS['tcn_user_meta'] ) || ! is_array( $GLOBALS['tcn_user_meta'] ) ) {
+            $GLOBALS['tcn_user_meta'] = array();
+        }
+
+        if ( ! isset( $GLOBALS['tcn_user_meta'][ $user_id ] ) || ! is_array( $GLOBALS['tcn_user_meta'][ $user_id ] ) ) {
+            $GLOBALS['tcn_user_meta'][ $user_id ] = array();
+        }
+
+        $GLOBALS['tcn_user_meta'][ $user_id ][ $meta_key ] = $meta_value;
+
+        return true;
+    }
+}
+
+if ( ! function_exists( 'get_user_meta' ) ) {
+    function get_user_meta( $user_id, $meta_key, $single = false ) {
+        if ( isset( $GLOBALS['tcn_user_meta'][ $user_id ][ $meta_key ] ) ) {
+            return $GLOBALS['tcn_user_meta'][ $user_id ][ $meta_key ];
+        }
+
+        return '';
+    }
+}
+
+if ( ! function_exists( 'delete_user_meta' ) ) {
+    function delete_user_meta( $user_id, $meta_key ) {
+        if ( isset( $GLOBALS['tcn_user_meta'][ $user_id ][ $meta_key ] ) ) {
+            unset( $GLOBALS['tcn_user_meta'][ $user_id ][ $meta_key ] );
+        }
+
+        return true;
+    }
+}
+
+if ( ! function_exists( 'user_can' ) ) {
+    function user_can( $user, $capability ) {
+        return false;
+    }
+}
+
+if ( ! class_exists( 'WP_User', false ) ) {
+    class WP_User {
+        public $ID;
+        public $user_login;
+        public $user_email;
+        public $user_pass;
+        public $display_name = '';
+        public $first_name = '';
+        public $last_name = '';
+
+        public function __construct( $id = 0, $user_login = '', $user_email = '', $user_pass = '' ) {
+            $this->ID         = $id;
+            $this->user_login = $user_login;
+            $this->user_email = $user_email;
+            $this->user_pass  = $user_pass;
+        }
+    }
+}
+
+class ArrayBackedRequest extends WP_REST_Request {
+    /**
+     * @var array<string, mixed>
+     */
+    private $params;
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function __construct( array $params ) {
+        parent::__construct();
+        $this->params = $params;
+    }
+
+    public function get_param( $key ) {
+        return $this->params[ $key ] ?? null;
+    }
+}
+
+class StubPasswordLoginService extends PasswordLoginService {
+    /**
+     * @var bool
+     */
+    public $rate_reset = false;
+
+    public function __construct() {
+        parent::__construct();
+
+        $this->settings = array(
+            'rate_limit'        => 5,
+            'rate_limit_window' => 60,
+            'token_lifetime'    => WEEK_IN_SECONDS,
+        );
+    }
+
+    protected function maybe_enforce_https( \WP_REST_Request $request ) {
+        return true;
+    }
+
+    protected function build_rate_context( string $action, string $identifier ): array {
+        return array(
+            'key'   => 'test-rate',
+            'limit' => 5,
+            'ttl'   => 60,
+        );
+    }
+
+    protected function is_rate_limited( array $context ): bool {
+        return false;
+    }
+
+    protected function increment_rate_limit( array $context ): void {}
+
+    protected function reset_rate_limit( array $context ): void {
+        $this->rate_reset = true;
+    }
+
+    protected function issue_login_token( int $user_id ): array {
+        return array(
+            'token'      => 'login-token',
+            'expires_in' => WEEK_IN_SECONDS,
+        );
+    }
+
+    protected function issue_api_token( int $user_id ): array {
+        return array(
+            'token'      => 'api-token',
+            'expires_in' => HOUR_IN_SECONDS,
+        );
+    }
+
+    protected function prepare_user_payload( \WP_User $user ): array {
+        return array( 'id' => $user->ID );
+    }
+
+    protected function get_woocommerce_credentials(): array {
+        return array();
+    }
+}
 
 final class PasswordLoginServiceTest extends TestCase {
     protected function setUp(): void {
@@ -13,6 +286,8 @@ final class PasswordLoginServiceTest extends TestCase {
         $_SERVER = array();
         $GLOBALS['tcn_test_headers'] = array();
         $GLOBALS['tcn_home_url']     = 'https://example.com';
+        $GLOBALS['tcn_test_users']   = array();
+        $GLOBALS['tcn_user_meta']    = array();
     }
 
     public function test_does_not_emit_cors_headers_for_unconfigured_third_party_origin(): void {
@@ -41,6 +316,36 @@ final class PasswordLoginServiceTest extends TestCase {
         );
 
         $this->assertContains('Access-Control-Allow-Origin: https://app.test', $headers);
+    }
+
+    public function test_login_accepts_email_when_provided_for_username_and_email(): void {
+        $user = new WP_User( 42, 'john_doe', 'john@example.com', 'secret' );
+
+        $GLOBALS['tcn_test_users'] = array( $user );
+
+        $service = new StubPasswordLoginService();
+
+        $request = new ArrayBackedRequest(
+            array(
+                'username' => 'john@example.com',
+                'email'    => 'john@example.com',
+                'password' => 'secret',
+            )
+        );
+
+        $result = $service->handle_login( $request );
+
+        $this->assertSame( false, is_wp_error( $result ) );
+        $this->assertSame( true, $service->rate_reset );
+        $this->assertSame( true, $result['success'] );
+        $this->assertSame( array( 'id' => 42 ), $result['user'] );
+        $this->assertSame( 'login-token', $result['token'] );
+        $this->assertSame( 'api-token', $result['api_token'] );
+        $this->assertSame( HOUR_IN_SECONDS, $result['expires_in'] );
+        $this->assertSame(
+            'https://example.com/wp-login.php?action=gn_token_login&token=login-token',
+            $result['token_login_url']
+        );
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -163,6 +163,10 @@ namespace {
     }
 
     require_once __DIR__ . '/../vendor/autoload.php';
+    require_once __DIR__ . '/../includes/Support/ErrorCodes.php';
+    if ( ! class_exists( '\\TCN\\Platform\\Auth\\ErrorCodes', false ) ) {
+        class_alias( '\\TCN\\Platform\\Support\\ErrorCodes', '\\TCN\\Platform\\Auth\\ErrorCodes' );
+    }
     require_once __DIR__ . '/../includes/Auth/TokenAuthenticator.php';
 }
 


### PR DESCRIPTION
## Summary
- treat login attempts that provide the account email for both username and email fields as valid during credential matching
- add a stubbed login test harness that exercises the email+email flow and ensure supporting WordPress shims exist for the scenario
- load the shared ErrorCodes helper for tests and bump the plugin metadata to version 0.3.99

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68fa417e73588327b2aa7759fedd91cb